### PR TITLE
deps: Remove overly restrictive dependancies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Natural Language :: English",
+  "License :: OSI Approved :: Apache Software License",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",
@@ -46,41 +47,41 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-ConfigSpace = "^0.4.19"
-grakel = "^0.1.9"
-numpy = "^1.23.0"
-pandas = "^1.3.1"
+ConfigSpace = "^0.6"
+grakel = "^0.1"
+numpy = "^1"
+pandas = "^2"
 networkx = "^2.6.3"
 nltk = "^3.6.4"
-path = "^16.2.0"
-termcolor = "^1.1.0"
-scipy = "^1.8"
+#path = "^16.2.0"
+#termcolor = "^1.1.0"
+scipy = "^1"
 torch = ">=1.7.0,<=2.1, !=2.0.1, !=2.1.0"  # fix from: https://stackoverflow.com/a/76647180
 # torch = [
 #     {version = ">=1.7.0,<=2.1", markers = "sys_platform == 'darwin'"},  # Segfaults for macOS on github actions
 #     {version = ">=1.7.0,<=2.1", markers = "sys_platform != 'darwin'"},
 # ]
-matplotlib = "^3.4"
-statsmodels = "^0.13.2"
-more-itertools = "^9.0.0"
-portalocker = "^2.6.0"
-seaborn = "^0.12.1"
-pyyaml = "^6.0"
-tensorboard = "^2.13"
-cython = "^3.0.4"
-torchvision = "<0.16.0"
+matplotlib = "^3"
+# statsmodels = "^0.13.2"
+more-itertools = "^10"
+portalocker = "^2"
+seaborn = "^0.13"
+pyyaml = "^6"
+tensorboard = "^2"
+# cython = "^3.0.4"
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "^2.10"
-mypy = "^0.930"
-pytest = "^6.2.5"
-types-PyYAML = "^6.0.12"
-typing-extensions = "^4.0.1"
-types-termcolor = "^1.1.2"
+pre-commit = "^3"
+mypy = "^1"
+pytest = "^7"
+types-PyYAML = "^6"
+typing-extensions = "^4"
+#types-termcolor = "^1.1.2"
 # jahs-bench = {git = "https://github.com/automl/jahs_bench_201.git", rev = "v1.0.2"}
 mkdocs-material = "^8.1.3"
 mike = "^1.1.2"
 gpytorch = "1.8.0"
+torchvision = "<0.16.0"  # Used in examples
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]

--- a/src/neps/search_spaces/architecture/graph.py
+++ b/src/neps/search_spaces/architecture/graph.py
@@ -12,7 +12,7 @@ from typing import Counter as CounterType
 import networkx as nx
 import torch
 from networkx.algorithms.dag import lexicographical_topological_sort
-from path import Path
+from pathlib import Path
 from torch import nn
 
 from ...utils.common import AttrDict


### PR DESCRIPTION
See: #25 

It's very hard to incorporate NePS into existing libraries due to overly restrictive dependancies. I made the less strict and ran the tests, everything passed.

Not sure if that's exhaustive enough though...