### PR TITLE
fix(dependacy): Check for specific Error

### DIFF
--- a/src/metahyper/exceptions.py
+++ b/src/metahyper/exceptions.py
@@ -1,0 +1,34 @@
+class MissingDependencyError(Exception):
+    """Used whenever an optional dependancy is missing."""
+
+    def __init__(
+        self,
+        *,
+        libname: str,
+        dep: str,
+        cause: Exception,
+        install_group: str | None = None,
+    ):
+        """Initialize the exception.
+
+        Args:
+            libname (str): The name of the library that is missing the dependency.
+            dep (str): The name of the dependency that is missing.
+            install_group (str, optional): The name of the dependency group to install.
+            cause (Exception): The exception that caused the error.
+        """
+        super().__init__(libname, dep, cause, install_group)
+        self.libname = libname
+        self.dep = dep
+        self.install_group = install_group
+        self.__cause__ = cause  # This is what `raise a from b` does
+
+    def __str__(self) -> str:
+        msg = f"Required dependency ({self.dep}) is missing for this optional feature."
+        if self.install_group is not None:
+            msg += (
+                f"Please install with {self.libname}[{self.install_group}] "
+                f"to be able to use all the optional features. Otherwise, "
+                f" just install ({self.dep})"
+            )
+        return msg

--- a/src/metahyper/utils.py
+++ b/src/metahyper/utils.py
@@ -8,6 +8,8 @@ from typing import Any, Callable
 
 import yaml
 
+from metahyper.exceptions import MissingDependencyError
+
 
 def non_empty_file(file_path: Path) -> bool:
     return file_path.exists() and file_path.stat().st_size != 0
@@ -93,7 +95,7 @@ def is_partial_class(obj):
 
 def instance_from_map(
     mapping: dict[str, Any],
-    request: str | list | tuple | Any,
+    request: str | list | tuple | Any | MissingDependencyError,
     name: str = "mapping",
     allow_any: bool = True,
     as_class: bool = False,
@@ -115,6 +117,10 @@ def instance_from_map(
         ValueError: if the request is invalid (not a string if allow_any is False),
             or invalid key.
     """
+    if isinstance(request, MissingDependencyError):
+        # This happens when some optional dependancy is missing, the error
+        # message will signal to the user what to do
+        raise request
 
     # Split arguments of the form (request, kwargs)
     args_dict = kwargs or {}
@@ -139,11 +145,6 @@ def instance_from_map(
         instance = request
     else:
         raise ValueError(f"Object {request} invalid key for {name}")
-
-    # The case for MissingDependencyError,
-    # but can't import it here due to circular import risk
-    if isinstance(instance, Exception):
-        raise instance
 
     # Check if the request is a class if it is mandatory
     if (args_dict or as_class) and not is_partial_class(instance):

--- a/src/neps/optimizers/bayesian_optimization/models/__init__.py
+++ b/src/neps/optimizers/bayesian_optimization/models/__init__.py
@@ -1,16 +1,17 @@
-from ....utils.common import MissingDependencyError
+from metahyper.exceptions import MissingDependencyError
+
 from .gp import ComprehensiveGP
 from .gp_hierarchy import ComprehensiveGPHierarchy
 
 try:
     from .deepGP import DeepGP
 except ImportError as e:
-    DeepGP = MissingDependencyError("gpytorch", e)
+    DeepGP = MissingDependencyError(libname="neps", dep="gpytorch", install_group="experimental", cause=e)
 
 try:
     from .pfn import PFN_SURROGATE  # only if available locally
 except Exception as e:
-    PFN_SURROGATE = MissingDependencyError("pfn", e)
+    PFN_SURROGATE = MissingDependencyError(libname="neps", dep="pfn", install_group="experimental", cause=e)
 
 SurrogateModelMapping = {
     "deep_gp": DeepGP,

--- a/src/neps/utils/common.py
+++ b/src/neps/utils/common.py
@@ -4,7 +4,6 @@ import glob
 import os
 import random
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import torch
@@ -89,6 +88,11 @@ def save_checkpoint(
             is "checkpoint.pth".
     """
     if directory is None:
+        if ConfigInRun.pipeline_directory is None:
+            raise ValueError(
+                "The pipeline directory is not set in `ConfigInRun`. Please"
+                " provide a `directory=` to `save_checkpoint()`."
+            )
         directory = ConfigInRun.pipeline_directory
 
     directory = Path(directory)
@@ -268,21 +272,6 @@ def set_rnd_state(state: dict):
     if torch.cuda.is_available() and "torch_cuda_seed_state" in state:
         torch.cuda.set_rng_state_all(
             [torch.ByteTensor(dev) for dev in state["torch_cuda_seed_state"]]
-        )
-
-
-class MissingDependencyError(Exception):
-    def __init__(self, dep: str, cause: Exception, *args: Any):
-        super().__init__(dep, cause, *args)
-        self.dep = dep
-        self.__cause__ = cause  # This is what `raise a from b` does
-
-    def __str__(self) -> str:
-        return (
-            f"Some required dependency-({self.dep}) to use this optional feature is "
-            f"missing. Please, include neps[experimental] dependency group in your "
-            f"installation of neps to be able to use all the optional features."
-            f" Otherwise, just install ({self.dep})"
         )
 
 

--- a/tests/test_metahyper/test_instance_mapping.py
+++ b/tests/test_metahyper/test_instance_mapping.py
@@ -1,0 +1,18 @@
+
+from metahyper.utils import instance_from_map
+from metahyper.exceptions import MissingDependencyError
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "err", [
+        MissingDependencyError(libname="neps", dep="test_dep_1", install_group="group_1", cause=ImportError()),
+        MissingDependencyError(libname="neps", dep="test_dep_2", install_group=None, cause=ImportError())
+    ]
+)
+@pytest.mark.metahyper
+def test_missing_dependancy_gets_flagged(err: MissingDependencyError) -> None:
+    with pytest.raises(MissingDependencyError, match=err.dep):
+        instance_from_map(mapping={}, request=err)
+


### PR DESCRIPTION
This changes a previous commit which just check for `Exception`. To make the code clearer, I made this instead check for the specific `MissingDependancyError`.

This was not done previously as the error was defined in `neps` but `instance_from_map` was in `metahyper`. I fixed this by just moving the error type definition to `metahyper` and making it a bit more general as a result.

Also fixed a linter error that was annoying me

