### PR TITLE
ci: Add concurrency group to save resources on github action tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,7 @@
 name: tests
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 on:
   push:
     paths:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,12 +3,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 on:
-  push:
-    paths:
-      - '**.py'
-      - 'pyproject.toml'
-      - '.github/workflows/**'
   workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   tests:


### PR DESCRIPTION
Some small changes, one to basically cancel previous tests if theres a new commit, i.e. you're working on a PR and make many small commits, it will only actively run tests on the most recent one and cancel any ones that are in progress for that PR.

Also made the tests run on more than just python files/workflows. Main reason being is the introduction of yaml files will also likely mean testing should be run.