### PR TITLE
doc: Directly link to API in docs, remove repetitions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,17 +11,19 @@ pip install neural-pipeline-search
 ```
 
 ## The 3 Main Components
-1. **Define a [`run_pipeline=`](./reference/run_pipeline.md) Function**: This function is essential
-for evaluating different configurations. You'll implement the specific logic for your problem within this function.
+1. **Execute with [`neps.run()`](./reference/neps_run.md)**:
+Optimize your `run_pipeline=` over the `pipeline_space=` using this function.
+For a thorough overview of the arguments and their explanations, check out the detailed documentation.
+
+2. **Define a [`run_pipeline=`](./reference/run_pipeline.md) Function**:
+This function is essential for evaluating different configurations.
+You'll implement the specific logic for your problem within this function.
 For detailed instructions on initializing and effectively using `run_pipeline=`, refer to the guide.
 
-2. **Establish a [`pipeline_space=`](./reference/pipeline_space.md)**: Your search space for
-defining parameters. You can structure this in various formats, including dictionaries, YAML, or ConfigSpace.
+3. **Establish a [`pipeline_space=`](./reference/pipeline_space.md)**:
+Your search space for defining parameters.
+You can structure this in various formats, including dictionaries, YAML, or ConfigSpace.
 The guide offers insights into defining and configuring your search space.
-
-3. **Execute with [`neps.run=`](./reference/neps_run.md)**: Optimize your `run_pipeline=` over
-the `pipeline_space=` using this function. For a thorough overview of the arguments and their explanations,
-check out the detailed documentation.
 
 By following these steps and utilizing the extensive resources provided in the guides, you can tailor NePS to meet
 your specific requirements, ensuring a streamlined and effective optimization process.

--- a/neps/search_spaces/hyperparameters/categorical.py
+++ b/neps/search_spaces/hyperparameters/categorical.py
@@ -17,13 +17,43 @@ CATEGORICAL_CONFIDENCE_SCORES = {
 
 
 class CategoricalParameter(Parameter):
+    """A set of **unordered** choices for a parameter.
+
+    This kind of [`Parameter`][neps.search_spaces.parameter] is used
+    to represent hyperparameters that can take on a discrete set of unordered
+    values. For example, the `optimizer` hyperparameter in a neural network
+    search space can be a `CategoricalParameter` with choices like
+    `#!python ["adam", "sgd", "rmsprop"]`.
+
+    ```python
+    import neps
+
+    optimizer_choice = neps.CategoricalParameter(
+        ["adam", "sgd", "rmsprop"],
+        default="adam"
+    )
+    ```
+    """
+
     def __init__(
         self,
         choices: Iterable[float | int | str],
+        *,
         is_fidelity: bool = False,
         default: None | float | int | str = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
+        """Create a new `CategoricalParameter`.
+
+        Args:
+            choices: choices for the hyperparameter.
+            is_fidelity: whether the hyperparameter is fidelity.
+            default: default value for the hyperparameter, must be in `choices=`
+                if provided.
+            default_confidence: confidence score for the default value, used when
+                condsider prior based optimization.
+        """
+
         super().__init__()
 
         self.default = default

--- a/neps/search_spaces/hyperparameters/constant.py
+++ b/neps/search_spaces/hyperparameters/constant.py
@@ -1,10 +1,30 @@
-from typing import Union
+from __future__ import annotations
 
-from .numerical import NumericalParameter
+from neps.search_spaces.hyperparameters.numerical import NumericalParameter
 
 
 class ConstantParameter(NumericalParameter):
-    def __init__(self, value: Union[float, int, str], is_fidelity: bool = False):
+    """A constant value for a parameter.
+
+    This kind of [`Parameter`][neps.search_spaces.parameter] is used
+    to represent hyperparameters with values that should not change during
+    optimization. For example, the `batch_size` hyperparameter in a neural
+    network search space can be a `ConstantParameter` with a value of `32`.
+
+    ```python
+    import neps
+
+    batch_size = neps.ConstantParameter(32)
+    ```
+    """
+
+    def __init__(self, value: int | float | str, *, is_fidelity: bool = False):
+        """Create a new `ConstantParameter`.
+
+        Args:
+            value: value for the hyperparameter.
+            is_fidelity: whether the hyperparameter is fidelity.
+        """
         super().__init__()
         self.value = value
         self.is_fidelity = is_fidelity

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -17,15 +17,44 @@ FLOAT_CONFIDENCE_SCORES = {
 
 
 class FloatParameter(NumericalParameter):
+    """A float value for a parameter.
+
+    This kind of [`Parameter`][neps.search_spaces.parameter] is used
+    to represent hyperparameters with continuous float values, optionally specifying if it exists
+    on a log scale.
+    For example, `l2_norm` could be a value in `(0.1)`, while the `learning_rate`
+    hyperparameter in a neural network search space can be a `FloatParameter`
+    with a range of `(0.0001, 0.1)` but on a log scale.
+
+    ```python
+    import neps
+
+    l2_norm = neps.FloatParameter(0, 1)
+    learning_rate = neps.FloatParameter(1e-4, 1e-1, log=True)
+    ```
+    """
+
     def __init__(
         self,
         lower: float | int,
         upper: float | int,
+        *,
         log: bool = False,
         is_fidelity: bool = False,
         default: None | float | int = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
+        """Create a new `FloatParameter`.
+
+        Args:
+            lower: lower bound for the hyperparameter.
+            upper: upper bound for the hyperparameter.
+            log: whether the hyperparameter is on a log scale.
+            is_fidelity: whether the hyperparameter is fidelity.
+            default: default value for the hyperparameter.
+            default_confidence: confidence score for the default value, used when
+                condsider prior based optimization.
+        """
         super().__init__(is_fidelity=is_fidelity)
 
         self.default = default

--- a/neps/search_spaces/hyperparameters/integer.py
+++ b/neps/search_spaces/hyperparameters/integer.py
@@ -8,16 +8,53 @@ from neps.search_spaces.hyperparameters.float import FloatParameter
 
 
 class IntegerParameter(FloatParameter):
+    """An integer value for a parameter.
+
+    This kind of [`Parameter`][neps.search_spaces.parameter] is used
+    to represent hyperparameters with continuous integer values, optionally specifying if it exists
+    on a log scale.
+    For example, `batch_size` could be a value in `(32, 128)`, while the `num_layers`
+    hyperparameter in a neural network search space can be a `IntegerParameter`
+    with a range of `(1, 1000)` but on a log scale.
+
+    ```python
+    import neps
+
+    batch_size = neps.IntegerParameter(32, 128)
+    num_layers = neps.IntegerParameter(1, 1000, log=True)
+    ```
+    """
+
     def __init__(
         self,
         lower: float | int,
         upper: float | int,
+        *,
         log: bool = False,
         is_fidelity: bool = False,
         default: None | float | int = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
-        super().__init__(lower, upper, log, is_fidelity, default, default_confidence)
+        """Create a new `IntegerParameter`.
+
+        Args:
+            lower: lower bound for the hyperparameter.
+            upper: upper bound for the hyperparameter.
+            log: whether the hyperparameter is on a log scale.
+            is_fidelity: whether the hyperparameter is fidelity.
+            default: default value for the hyperparameter.
+            default_confidence: confidence score for the default value, used when
+                condsider prior based optimization.
+        """
+
+        super().__init__(
+            lower,
+            upper,
+            log=log,
+            is_fidelity=is_fidelity,
+            default=default,
+            default_confidence=default_confidence,
+        )
         # We subtract/add 0.499999 from lower/upper bounds respectively, such that
         # sampling in the float space gives equal probability for all integer values,
         # i.e. [x - 0.499999, x + 0.499999]

--- a/tests/test_yaml_search_space/test_search_space.py
+++ b/tests/test_yaml_search_space/test_search_space.py
@@ -17,19 +17,19 @@ def test_correct_yaml_files():
         """Test the function with a correctly formatted YAML file."""
         pipeline_space = pipeline_space_from_yaml(path)
         assert isinstance(pipeline_space, dict)
-        float1 = FloatParameter(0.00001, 0.1, True, False)
+        float1 = FloatParameter(0.00001, 0.1, log=True, is_fidelity=False)
         assert float1.__eq__(pipeline_space["param_float1"]) is True
-        int1 = IntegerParameter(-3, 30, False, True)
+        int1 = IntegerParameter(-3, 30, log=False, is_fidelity=True)
         assert int1.__eq__(pipeline_space["param_int1"]) is True
-        int2 = IntegerParameter(100, 30000, True, False)
+        int2 = IntegerParameter(100, 30000, log=True, is_fidelity=False)
         assert int2.__eq__(pipeline_space["param_int2"]) is True
-        float2 = FloatParameter(3.3e-5, 0.15, False, False)
+        float2 = FloatParameter(3.3e-5, 0.15, log=False,is_fidelity= False)
         assert float2.__eq__(pipeline_space["param_float2"]) is True
-        cat1 = CategoricalParameter([2, "sgd", 10e-3], False)
+        cat1 = CategoricalParameter([2, "sgd", 10e-3],is_fidelity= False)
         assert cat1.__eq__(pipeline_space["param_cat"]) is True
-        const1 = ConstantParameter(0.5, False)
+        const1 = ConstantParameter(0.5,is_fidelity= False)
         assert const1.__eq__(pipeline_space["param_const1"]) is True
-        const2 = ConstantParameter(1e3, True)
+        const2 = ConstantParameter(1e3,is_fidelity= True)
         assert const2.__eq__(pipeline_space["param_const2"]) is True
 
     test_correct_yaml_file(BASE_PATH + "correct_config.yaml")
@@ -43,13 +43,13 @@ def test_correct_including_priors_yaml_file():
         BASE_PATH + "correct_config_including_priors.yml"
     )
     assert isinstance(pipeline_space, dict)
-    float1 = FloatParameter(0.00001, 0.1, True, False, 3.3e-2, "high")
+    float1 = FloatParameter(0.00001, 0.1, log=True, is_fidelity=False, default=3.3e-2, default_confidence="high")
     assert float1.__eq__(pipeline_space["learning_rate"]) is True
-    int1 = IntegerParameter(3, 30, False, True, 10)
+    int1 = IntegerParameter(3, 30, log=False, is_fidelity=True, default=10)
     assert int1.__eq__(pipeline_space["num_epochs"]) is True
-    cat1 = CategoricalParameter(["adam", 90e-3, "rmsprop"], False, 90e-3, "medium")
+    cat1 = CategoricalParameter(["adam", 90e-3, "rmsprop"], is_fidelity=False, default=90e-3, default_confidence="medium")
     assert cat1.__eq__(pipeline_space["optimizer"]) is True
-    const1 = ConstantParameter(1e3, True)
+    const1 = ConstantParameter(1e3, is_fidelity=True)
     assert const1.__eq__(pipeline_space["dropout_rate"]) is True
 
 


### PR DESCRIPTION
* Closes issue #76 

This PR mainly cleans up the search space and analyses doc pages by linking directly to the code docstrings (API) doc but also re-organizing things slightly to favour simpler concepts first.

* Search Space: Introduce parameters first before all the ways you can define and pass them in
* Analysis: Give short intro to `python -m status` and `python -m plot` first before introducing tblogger. Show example usage of function in the docs.