### PR TITLE
refactor(SearchSpace): Switch to `clone()` for search space.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.err
 *.log
 *.json
+*.speedscope
 
 # slurm scripts
 slurm_scripts/*

--- a/neps/optimizers/base_optimizer.py
+++ b/neps/optimizers/base_optimizer.py
@@ -8,9 +8,9 @@ from typing_extensions import Self
 from contextlib import contextmanager
 from pathlib import Path
 
-from neps.utils.types import ConfigResult
+from neps.utils.types import ConfigResult, RawConfig, ERROR, ResultDict
 from neps.utils.files import serialize, deserialize
-from ..search_spaces.search_space import SearchSpace
+from neps.search_spaces.search_space import SearchSpace
 from neps.utils.data_loading import _get_cost, _get_learning_curve, _get_loss
 
 
@@ -50,7 +50,7 @@ class BaseOptimizer:
         raise NotImplementedError
 
     @abstractmethod
-    def get_config_and_ids(self) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """Sample a new configuration
 
         Returns:
@@ -79,7 +79,7 @@ class BaseOptimizer:
         config.load_from(config_dict)
         return config
 
-    def get_loss(self, result: str | dict | float) -> float | Any:
+    def get_loss(self, result: ERROR | ResultDict | float) -> float | Any:
         """Calls result.utils.get_loss() and passes the error handling through.
         Please use self.get_loss() instead of get_loss() in all optimizer classes."""
         return _get_loss(
@@ -88,7 +88,7 @@ class BaseOptimizer:
             ignore_errors=self.ignore_errors,
         )
 
-    def get_cost(self, result: str | dict | float) -> float | Any:
+    def get_cost(self, result: ERROR | ResultDict | float) -> float | Any:
         """Calls result.utils.get_cost() and passes the error handling through.
         Please use self.get_cost() instead of get_cost() in all optimizer classes."""
         return _get_cost(

--- a/neps/optimizers/base_optimizer.py
+++ b/neps/optimizers/base_optimizer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
-from copy import deepcopy
 from typing import Any, Iterator, Mapping
 from typing_extensions import Self
 from contextlib import contextmanager
@@ -75,7 +74,7 @@ class BaseOptimizer:
         self.used_budget = state["used_budget"]
 
     def load_config(self, config_dict: Mapping[str, Any]) -> SearchSpace:
-        config = deepcopy(self.pipeline_space)
+        config = self.pipeline_space.clone()
         config.load_from(config_dict)
         return config
 

--- a/neps/optimizers/bayesian_optimization/acquisition_functions/__init__.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_functions/__init__.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 from functools import partial
 from typing import Callable
 
-from .ei import ComprehensiveExpectedImprovement
-from .mf_ei import MFEI
-from .ucb import UpperConfidenceBound, MF_UCB
+from neps.optimizers.bayesian_optimization.acquisition_functions.ei import (
+    ComprehensiveExpectedImprovement,
+)
+from neps.optimizers.bayesian_optimization.acquisition_functions.mf_ei import MFEI
+from neps.optimizers.bayesian_optimization.acquisition_functions.ucb import (
+    UpperConfidenceBound,
+    MF_UCB,
+)
+from neps.optimizers.bayesian_optimization.acquisition_functions.prior_weighted import (
+    DecayingPriorWeightedAcquisition,
+)
 
 
 AcquisitionMapping: dict[str, Callable] = {
@@ -41,3 +49,12 @@ AcquisitionMapping: dict[str, Callable] = {
         maximize=False,
     ),
 }
+
+__all__ = [
+    "AcquisitionMapping",
+    "ComprehensiveExpectedImprovement",
+    "MFEI",
+    "UpperConfidenceBound",
+    "MF_UCB",
+    "DecayingPriorWeightedAcquisition",
+]

--- a/neps/optimizers/bayesian_optimization/acquisition_functions/ei.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_functions/ei.py
@@ -57,11 +57,13 @@ class ComprehensiveExpectedImprovement(BaseAcquisition):
         Return the negative expected improvement at the query point x2
         """
         assert self.incumbent is not None, "EI function not fitted on model"
-        _x = [elem.clone() for elem in x]
 
-        if _x[0].has_fidelity and self.optimize_on_max_fidelity:
-            for elem in _x:
-                elem.set_to_max_fidelity()
+        if x[0].has_fidelity and self.optimize_on_max_fidelity:
+            _x = [e.clone() for e in x]
+            for e in _x:
+                e.set_to_max_fidelity()
+        else:
+            _x = x
 
         try:
             mu, cov = self.surrogate_model.predict(_x)

--- a/neps/optimizers/bayesian_optimization/acquisition_functions/mf_ei.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_functions/mf_ei.py
@@ -55,13 +55,13 @@ class MFEI(ComprehensiveExpectedImprovement):
 
                 if np.less_equal(target_fidelity, config.fidelity.upper):
                     # only consider the configs with fidelity lower than the max fidelity
-                    config.fidelity.value = target_fidelity
+                    config.fidelity.set_value(target_fidelity)
                     budget_list.append(self.get_budget_level(config))
                 else:
                     # if the target_fidelity higher than the max drop the configuration
                     indices_to_drop.append(i)
             else:
-                config.fidelity.value = target_fidelity
+                config.fidelity.set_value(target_fidelity)
                 budget_list.append(self.get_budget_level(config))
 
         # Drop unused configs

--- a/neps/optimizers/bayesian_optimization/acquisition_functions/prior_weighted.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_functions/prior_weighted.py
@@ -13,6 +13,7 @@ class DecayingPriorWeightedAcquisition(BaseAcquisition):
         pibo_beta=10,
         log: bool = False,
     ):
+        super().__init__()
         self.pibo_beta = pibo_beta
         self.base_acquisition = base_acquisition
         self.log = log
@@ -23,11 +24,11 @@ class DecayingPriorWeightedAcquisition(BaseAcquisition):
         x: Iterable,
         **base_acquisition_kwargs,
     ) -> Union[np.ndarray, torch.Tensor, float]:
-        super().__init__()
         acquisition = self.base_acquisition(x, **base_acquisition_kwargs)
 
         if self.log:
             min_acq_val = abs(min(acquisition)) if min(acquisition) < 0 else 0
+
         for i, candidate in enumerate(x):
             prior_weight = candidate.compute_prior(log=self.log)
             if prior_weight != 1.0:

--- a/neps/optimizers/bayesian_optimization/acquisition_samplers/base_acq_sampler.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_samplers/base_acq_sampler.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from typing import TYPE_CHECKING, Sequence, Callable
 
-import torch
+from neps.types import Array
 
-from ....search_spaces.search_space import SearchSpace
+if TYPE_CHECKING:
+    from neps.search_spaces.search_space import SearchSpace
 
 
 class AcquisitionSampler:
@@ -14,17 +16,17 @@ class AcquisitionSampler:
 
         self.pipeline_space = pipeline_space
         self.acquisition_function = None
-        self.x: list = []
-        self.y: list = []
+        self.x: list[SearchSpace] = []
+        self.y: Sequence[float] | Array = []
         self.patience = patience
 
     @abstractmethod
-    def sample(self, acquisition_function) -> SearchSpace:
+    def sample(self, acquisition_function: Callable) -> SearchSpace:
         raise NotImplementedError
 
-    def sample_batch(self, acquisition_function, batch) -> list[SearchSpace]:
+    def sample_batch(self, acquisition_function: Callable, batch: int) -> list[SearchSpace]:
         return [self.sample(acquisition_function) for _ in range(batch)]
 
-    def set_state(self, x: list, y: list | torch.Tensor) -> None:
+    def set_state(self, x: list[SearchSpace], y: Sequence[float] | Array) -> None:
         self.x = x
         self.y = y

--- a/neps/optimizers/bayesian_optimization/acquisition_samplers/base_acq_sampler.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_samplers/base_acq_sampler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Sequence, Callable
 
-from neps.types import Array
+from neps.utils.types import Array
 
 if TYPE_CHECKING:
     from neps.search_spaces.search_space import SearchSpace

--- a/neps/optimizers/bayesian_optimization/acquisition_samplers/freeze_thaw_sampler.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_samplers/freeze_thaw_sampler.py
@@ -151,7 +151,7 @@ class FreezeThawSampler(AcquisitionSampler):
         partial_configs_list = []
         index_list = []
         for idx, config in partial_configs.items():
-            _config = deepcopy(config)
+            _config = config.clone()
             partial_configs_list.append(_config)
             index_list.append(idx)
 

--- a/neps/optimizers/bayesian_optimization/acquisition_samplers/freeze_thaw_sampler.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_samplers/freeze_thaw_sampler.py
@@ -13,7 +13,7 @@ from .base_acq_sampler import AcquisitionSampler
 
 
 class FreezeThawSampler(AcquisitionSampler):
-    
+
     SAMPLES_TO_DRAW = 100  # number of random samples to draw at lowest fidelity
 
     def __init__(self, **kwargs):
@@ -119,8 +119,8 @@ class FreezeThawSampler(AcquisitionSampler):
             config = self.pipeline_space.sample(
                 patience=self.patience, user_priors=False, ignore_fidelity=False
             )
-            config["id"].value = _new_configs[index]
-            config.fidelity.value = set_new_sample_fidelity
+            config["id"].set_value(_new_configs[index])
+            config.fidelity.set_value(set_new_sample_fidelity)
             return config
 
         if self.is_tabular:
@@ -131,7 +131,7 @@ class FreezeThawSampler(AcquisitionSampler):
             # accounting for unseen configs only, samples remaining table if flag is set
             max_n = len(_all_ids) + 1 if self.sample_full_table else _n
             _n = min(max_n, len(_all_ids - _partial_ids))
-            
+
             _new_configs = np.random.choice(
                 list(_all_ids - _partial_ids), size=_n, replace=False
             )
@@ -145,7 +145,7 @@ class FreezeThawSampler(AcquisitionSampler):
 
         elif set_new_sample_fidelity is not None:
             for config in new_configs:
-                config.fidelity.value = set_new_sample_fidelity
+                config.fidelity.set_value(set_new_sample_fidelity)
 
         # Deep copy configs for fidelity updates
         partial_configs_list = []

--- a/neps/optimizers/bayesian_optimization/acquisition_samplers/mutation_sampler.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_samplers/mutation_sampler.py
@@ -11,7 +11,7 @@ from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler
 from neps.optimizers.bayesian_optimization.acquisition_samplers.random_sampler import RandomSampler
 
 if TYPE_CHECKING:
-    from neps.types import Array
+    from neps.utils.types import Array
     from neps.search_spaces.search_space import SearchSpace
 
 

--- a/neps/optimizers/bayesian_optimization/acquisition_samplers/mutation_sampler.py
+++ b/neps/optimizers/bayesian_optimization/acquisition_samplers/mutation_sampler.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import TYPE_CHECKING, Callable, Sequence
 
 import numpy as np
 import torch
 from more_itertools import first
+from typing_extensions import override
 
-from .base_acq_sampler import AcquisitionSampler
-from .random_sampler import RandomSampler
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import AcquisitionSampler
+from neps.optimizers.bayesian_optimization.acquisition_samplers.random_sampler import RandomSampler
+
+if TYPE_CHECKING:
+    from neps.types import Array
+    from neps.search_spaces.search_space import SearchSpace
 
 
 def _propose_location(
-    acquisition_function,
-    candidates: list,
+    acquisition_function: Callable,
+    candidates: list[SearchSpace],
     top_n: int = 5,
     return_distinct: bool = True,
-) -> tuple[Iterable, np.ndarray, np.ndarray]:
+) -> tuple[list[SearchSpace], np.ndarray | torch.Tensor, np.ndarray]:
     """top_n: return the top n candidates wrt the acquisition function."""
     if return_distinct:
         eis = acquisition_function(candidates, asscalar=True)  # faster
@@ -29,6 +34,7 @@ def _propose_location(
     else:
         eis = torch.tensor([acquisition_function(c) for c in candidates])
         _, indices = eis.topk(top_n)
+
     xs = [candidates[int(i)] for i in indices]
     return xs, eis, indices
 
@@ -39,7 +45,7 @@ class MutationSampler(AcquisitionSampler):
         pipeline_space,
         pool_size: int = 250,
         n_best: int = 10,
-        mutate_size: int = None,
+        mutate_size: int | None = None,
         allow_isomorphism: bool = False,
         check_isomorphism_history: bool = True,
         patience: int = 50,
@@ -57,14 +63,21 @@ class MutationSampler(AcquisitionSampler):
             pipeline_space=pipeline_space, patience=patience
         )
 
-    def set_state(self, x, y) -> None:
+    @override
+    def set_state(self, x: list[SearchSpace], y: Sequence[float] | Array) -> None:
         super().set_state(x, y)
         self.random_sampling.set_state(x, y)
 
-    def sample(self, acquisition_function) -> tuple[list, list, np.ndarray]:
-        return first(self.sample_batch(acquisition_function, 1))
+    @override
+    def sample(self, acquisition_function: Callable) -> SearchSpace:
+        return first(self.sample_batch(acquisition_function, batch=1))
 
-    def sample_batch(self, acquisition_function, batch):
+    @override
+    def sample_batch(
+        self,
+        acquisition_function: Callable,
+        batch: int,
+    ) -> list[SearchSpace]:
         pool = self.create_pool(acquisition_function, self.pool_size)
 
         samples, _, _ = _propose_location(
@@ -74,7 +87,11 @@ class MutationSampler(AcquisitionSampler):
         )
         return samples
 
-    def create_pool(self, acquisition_function, pool_size: int) -> list:
+    def create_pool(
+        self,
+        acquisition_function: Callable,
+        pool_size: int,
+    ) -> list[SearchSpace]:
         if len(self.x) == 0:
             return self.random_sampling.sample_batch(acquisition_function, pool_size)
 
@@ -89,8 +106,14 @@ class MutationSampler(AcquisitionSampler):
         best_configs = [
             x for (_, x) in sorted(zip(self.y, self.x), key=lambda pair: pair[0])
         ][:n_best]
+
+        seen: set[int] = set()
+        def _hash(_config: SearchSpace) -> int:
+            return hash(_config.hp_values().values())
+
         evaluation_pool = []
         per_arch = mutate_size // n_best
+
         for config in best_configs:
             remaining_patience = self.patience
             for _ in range(per_arch):
@@ -101,15 +124,17 @@ class MutationSampler(AcquisitionSampler):
                     except Exception:
                         remaining_patience -= 1
                         continue
+                    hash_child = _hash(child)
 
                     if not self.allow_isomorphism:
                         # if disallow isomorphism, we enforce that each time, we mutate n distinct graphs.
                         # For now we do not check the isomorphism in all of the previous graphs though
-                        if child == config or child in evaluation_pool:
+                        if child == config or hash_child in seen:
                             remaining_patience -= 1
                             continue
 
                     evaluation_pool.append(child)
+                    seen.add(hash_child)
                     break
 
         # Fill missing pool with random samples

--- a/neps/optimizers/bayesian_optimization/kernels/utils.py
+++ b/neps/optimizers/bayesian_optimization/kernels/utils.py
@@ -1,7 +1,12 @@
-from typing import Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
 
 import networkx as nx
 import numpy as np
+
+if TYPE_CHECKING:
+    from neps.search_spaces.search_space import SearchSpace
 
 
 def transform_to_undirected(gr: list):
@@ -17,7 +22,7 @@ def transform_to_undirected(gr: list):
     return undirected_gr
 
 
-def extract_configs(configs: list) -> Tuple[list, list]:
+def extract_configs(configs: list[SearchSpace]) -> Tuple[list, list]:
     """Extracts graph & HPs from configs objects
 
     Args:

--- a/neps/optimizers/bayesian_optimization/mf_tpe.py
+++ b/neps/optimizers/bayesian_optimization/mf_tpe.py
@@ -608,7 +608,7 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
         current_rung = self.inverse_rung_map[next_config.fidelity.value]
         self.old_configs_per_fid[current_rung].append(next_config.copy())
         new_fidelity = self.rung_map[current_rung + 1]
-        next_config.fidelity.value = new_fidelity
+        next_config.fidelity.set_value(new_fidelity)
         return next_config
 
     def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
@@ -617,20 +617,20 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
             config = self.pipeline_space.sample(
                 patience=self.patience, user_priors=True, ignore_fidelity=False
             )
-            config.fidelity.value = self.rung_map[self.min_rung]
+            config.fidelity.set_value(self.rung_map[self.min_rung])
 
         elif self.is_init_phase():
             config = self.pipeline_space.sample(
                 patience=self.patience, user_priors=True, ignore_fidelity=True
             )
-            config.fidelity.value = self.rung_map[self.min_rung]
+            config.fidelity.set_value(self.rung_map[self.min_rung])
 
         elif random.random() < self._random_interleave_prob:
             # TODO only at lowest fidelity
             config = self.pipeline_space.sample(
                 patience=self.patience, ignore_fidelity=False, user_priors=False
             )
-            config.fidelity.value = self.rung_map[self.min_rung]
+            config.fidelity.set_vlaue(self.rung_map[self.min_rung])
         elif len(self._get_promotable_configs(self.train_x_configs)) > 0:
             configs_for_promotion = self._get_promotable_configs(self.train_x_configs)
             config = self._promote_existing(configs_for_promotion)
@@ -638,7 +638,7 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
         else:
             config = self.acquisition_sampler.sample(self.acquisition)
             print([hp.value for hp in config.hyperparameters.values()])
-            config.fidelity.value = self.rung_map[self.min_rung]
+            config.fidelity.set_value(self.rung_map[self.min_rung])
 
         config_id = str(self._num_train_x + len(self._pending_evaluations) + 1)
         return config.hp_values(), config_id, None

--- a/neps/optimizers/bayesian_optimization/models/deepGP.py
+++ b/neps/optimizers/bayesian_optimization/models/deepGP.py
@@ -268,7 +268,7 @@ class DeepGP:
                 label = hp.value
                 categorical_encoding[np.argwhere(self.categories_array == label)] = 1
             else:
-                continuous_values.append(hp.normalized().value)
+                continuous_values.append(hp.value_to_normalized(hp.value))
 
         continuous_encoding = np.array(continuous_values)
 

--- a/neps/optimizers/bayesian_optimization/optimizer.py
+++ b/neps/optimizers/bayesian_optimization/optimizer.py
@@ -187,7 +187,6 @@ class BayesianOptimization(BaseOptimizer):
             kwargs={"patience": self.patience, "pipeline_space": self.pipeline_space},
         )
         self._enhance_priors()
-        print()
 
     def _enhance_priors(self, confidence_score: dict = None) -> None:
         """Only applicable when priors are given along with a confidence.

--- a/neps/optimizers/bayesian_optimization/optimizer.py
+++ b/neps/optimizers/bayesian_optimization/optimizer.py
@@ -1,36 +1,43 @@
 from __future__ import annotations
 
 import random
-from typing import Any
+from typing import Any, TYPE_CHECKING, Literal
 
-from typing_extensions import Literal
-
-from neps.utils.types import ConfigResult
+from neps.utils.types import ConfigResult, RawConfig
 from neps.utils.common import instance_from_map
-from ...search_spaces.hyperparameters.categorical import (
-    CATEGORICAL_CONFIDENCE_SCORES,
+from neps.search_spaces import (
     CategoricalParameter,
-)
-from ...search_spaces.hyperparameters.constant import ConstantParameter
-from ...search_spaces.hyperparameters.float import (
-    FLOAT_CONFIDENCE_SCORES,
+    ConstantParameter,
     FloatParameter,
+    IntegerParameter,
+    SearchSpace,
 )
-from ...search_spaces.hyperparameters.integer import IntegerParameter
-from ...search_spaces.search_space import SearchSpace
-from ..base_optimizer import BaseOptimizer
-from .acquisition_functions import AcquisitionMapping
-from .acquisition_functions.base_acquisition import BaseAcquisition
-from .acquisition_functions.prior_weighted import DecayingPriorWeightedAcquisition
-from .acquisition_samplers import AcquisitionSamplerMapping
-from .acquisition_samplers.base_acq_sampler import AcquisitionSampler
-from .kernels.get_kernels import get_kernels
-from .models import SurrogateModelMapping
+from neps.optimizers.base_optimizer import BaseOptimizer
+from neps.optimizers.bayesian_optimization.acquisition_functions import (
+    AcquisitionMapping,
+    DecayingPriorWeightedAcquisition,
+)
+from neps.optimizers.bayesian_optimization.acquisition_samplers import (
+    AcquisitionSamplerMapping,
+)
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import (
+    AcquisitionSampler,
+)
+from neps.optimizers.bayesian_optimization.kernels.get_kernels import get_kernels
+from neps.optimizers.bayesian_optimization.models import SurrogateModelMapping
 
-CUSTOM_FLOAT_CONFIDENCE_SCORES = FLOAT_CONFIDENCE_SCORES.copy()
+if TYPE_CHECKING:
+    from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
+        BaseAcquisition,
+    )
+
+# TODO(eddiebergman): Why not just include in the definition of the parameters.
+CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(FloatParameter.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
-CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = CATEGORICAL_CONFIDENCE_SCORES.copy()
+CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
+    CategoricalParameter.DEFAULT_CONFIDENCE_SCORES
+)
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES.update({"ultra": 8})
 
 
@@ -152,9 +159,9 @@ class BayesianOptimization(BaseOptimizer):
             raise ValueError("No kernels are provided!")
 
         if "vectorial_features" not in surrogate_model_args:
-            surrogate_model_args[
-                "vectorial_features"
-            ] = self.pipeline_space.get_vectorial_dim()
+            surrogate_model_args["vectorial_features"] = (
+                self.pipeline_space.get_vectorial_dim()
+            )
 
         self.surrogate_model = instance_from_map(
             SurrogateModelMapping,
@@ -267,7 +274,7 @@ class BayesianOptimization(BaseOptimizer):
                     ) from runtime_error
                 self._model_update_failed = True
 
-    def get_config_and_ids(self) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         if (
             self._num_train_x == 0
             and self.sample_default_first

--- a/neps/optimizers/grid_search/optimizer.py
+++ b/neps/optimizers/grid_search/optimizer.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import random
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.search_space import SearchSpace
-from ..base_optimizer import BaseOptimizer
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.base_optimizer import BaseOptimizer
 
 
 class GridSearch(BaseOptimizer):
@@ -14,7 +14,8 @@ class GridSearch(BaseOptimizer):
         super().__init__(pipeline_space=pipeline_space, **optimizer_kwargs)
         self._num_previous_configs: int = 0
         self.configs_list = self.pipeline_space.get_search_space_grid(
-            grid_step_size=grid_step_size
+            size_per_numerical_hp=grid_step_size,
+            include_endpoints=True,
         )
         random.shuffle(self.configs_list)
 
@@ -25,7 +26,7 @@ class GridSearch(BaseOptimizer):
     ) -> None:
         self._num_previous_configs = len(previous_results) + len(pending_evaluations)
 
-    def get_config_and_ids(self) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         if self._num_previous_configs > len(self.configs_list) - 1:
             raise ValueError("Grid search exhausted!")
         config = self.configs_list[self._num_previous_configs]

--- a/neps/optimizers/multi_fidelity/_dyhpo.py
+++ b/neps/optimizers/multi_fidelity/_dyhpo.py
@@ -365,7 +365,7 @@ class MFEIBO(BaseOptimizer):
                     if np.less_equal(
                         self.get_budget_value(next_budget), config.fidelity.upper
                     ):
-                        config.fidelity.value = self.get_budget_value(next_budget)
+                        config.fidelity.set_value(self.get_budget_value(next_budget))
                         _config_id = promoted_config_id
                         fidelity_value_set = True
                         break
@@ -393,7 +393,7 @@ class MFEIBO(BaseOptimizer):
                 )
 
         if not fidelity_value_set:
-            config.fidelity.value = self.get_budget_value(0)
+            config.fidelity.set_value(self.get_budget_value(0))
 
         if _config_id is None:
             _config_id = (

--- a/neps/optimizers/multi_fidelity/_dyhpo.py
+++ b/neps/optimizers/multi_fidelity/_dyhpo.py
@@ -1,25 +1,26 @@
-# mypy: disable-error-code = assignment
+from __future__ import annotations
+
 from typing import Any, List, Union
 
 import numpy as np
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.search_space import FloatParameter, IntegerParameter, SearchSpace
-from ..base_optimizer import BaseOptimizer
-from ..bayesian_optimization.acquisition_functions.base_acquisition import (
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.search_space import FloatParameter, IntegerParameter, SearchSpace
+from neps.optimizers.base_optimizer import BaseOptimizer
+from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
     BaseAcquisition,
 )
-from ..bayesian_optimization.acquisition_samplers.base_acq_sampler import (
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import (
     AcquisitionSampler,
 )
-from .promotion_policy import PromotionPolicy
-from .sampling_policy import (
+from neps.optimizers.multi_fidelity.promotion_policy import PromotionPolicy
+from neps.optimizers.multi_fidelity.sampling_policy import (
     BaseDynamicModelPolicy,
     ModelPolicy,
     RandomPromotionDynamicPolicy,
     SamplingPolicy,
 )
-from .utils import MFObservedData
+from neps.optimizers.multi_fidelity.utils import MFObservedData
 
 
 class MFEIBO(BaseOptimizer):
@@ -279,9 +280,7 @@ class MFEIBO(BaseOptimizer):
         ID of the promoted configuration, else return None.
         """
         if promotion_type == "model":
-            config_id = self.model_policy.sample(
-                is_promotion=True, **self.sampling_args
-            )
+            config_id = self.model_policy.sample(is_promotion=True, **self.sampling_args)
         elif promotion_type == "policy":
             config_id = self.promotion_policy.retrieve_promotions()
         elif promotion_type is None:
@@ -322,9 +321,7 @@ class MFEIBO(BaseOptimizer):
 
         return config
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, Union[str, None]]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, Union[str, None]]:
         """...and this is the method that decides which point to query.
 
         Returns:

--- a/neps/optimizers/multi_fidelity/dyhpo.py
+++ b/neps/optimizers/multi_fidelity/dyhpo.py
@@ -1,28 +1,26 @@
-# mypy: disable-error-code = assignment
-# type: ignore
 from __future__ import annotations
 
 from typing import Any
 
 import numpy as np
 
-from neps.utils.types import ConfigResult
+from neps.utils.types import ConfigResult, RawConfig
 from neps.utils.common import instance_from_map
-from ...search_spaces.search_space import FloatParameter, IntegerParameter, SearchSpace
-from ..base_optimizer import BaseOptimizer
-from ..bayesian_optimization.acquisition_functions import AcquisitionMapping
-from ..bayesian_optimization.acquisition_functions.base_acquisition import (
+from neps.search_spaces.search_space import FloatParameter, IntegerParameter, SearchSpace
+from neps.optimizers.base_optimizer import BaseOptimizer
+from neps.optimizers.bayesian_optimization.acquisition_functions import AcquisitionMapping
+from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
     BaseAcquisition,
 )
-from ..bayesian_optimization.acquisition_samplers import AcquisitionSamplerMapping
-from ..bayesian_optimization.acquisition_samplers.base_acq_sampler import (
+from neps.optimizers.bayesian_optimization.acquisition_samplers import (
+    AcquisitionSamplerMapping,
+)
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import (
     AcquisitionSampler,
 )
-from ..bayesian_optimization.kernels.get_kernels import get_kernels
-from .mf_bo import FreezeThawModel, PFNSurrogate
-
-# MFEIDeepModel, MFEIModel
-from .utils import MFObservedData
+from neps.optimizers.bayesian_optimization.kernels.get_kernels import get_kernels
+from neps.optimizers.multi_fidelity.mf_bo import FreezeThawModel, PFNSurrogate
+from neps.optimizers.multi_fidelity.utils import MFObservedData
 
 
 class MFEIBO(BaseOptimizer):
@@ -33,7 +31,7 @@ class MFEIBO(BaseOptimizer):
     def __init__(
         self,
         pipeline_space: SearchSpace,
-        budget: int = None,
+        budget: int | None = None,
         step_size: int | float = 1,
         optimal_assignment: bool = False,
         use_priors: bool = False,
@@ -46,18 +44,18 @@ class MFEIBO(BaseOptimizer):
         logger=None,
         # arguments for model
         surrogate_model: str | Any = "deep_gp",
-        surrogate_model_args: dict = None,
-        domain_se_kernel: str = None,
-        graph_kernels: list = None,
-        hp_kernels: list = None,
+        surrogate_model_args: dict | None = None,
+        domain_se_kernel: str | None = None,
+        graph_kernels: list | None = None,
+        hp_kernels: list | None = None,
         acquisition: str | BaseAcquisition = acquisition,
-        acquisition_args: dict = None,
+        acquisition_args: dict | None = None,
         acquisition_sampler: str | AcquisitionSampler = "freeze-thaw",
-        acquisition_sampler_args: dict = None,
+        acquisition_sampler_args: dict | None = None,
         model_policy: Any = FreezeThawModel,
         initial_design_fraction: float = 0.75,
         initial_design_size: int = 10,
-        initial_design_budget: int = None,
+        initial_design_budget: int | None = None,
     ):
         """Initialise
 
@@ -86,9 +84,7 @@ class MFEIBO(BaseOptimizer):
             ignore_errors=ignore_errors,
             logger=logger,
         )
-        self.raw_tabular_space = (
-            None  # placeholder, can be populated using pre_load_hook
-        )
+        self.raw_tabular_space = None  # placeholder, can be populated using pre_load_hook
         self._budget_list: list[int | float] = []
         self.step_size: int | float = step_size
         self.min_budget = self.pipeline_space.fidelity.lower
@@ -409,9 +405,7 @@ class MFEIBO(BaseOptimizer):
         config.fidelity.value = new_fidelity
         return config, _config_id
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:

--- a/neps/optimizers/multi_fidelity/hyperband.py
+++ b/neps/optimizers/multi_fidelity/hyperband.py
@@ -1,5 +1,3 @@
-# type: ignore
-
 from __future__ import annotations
 
 import typing
@@ -9,23 +7,26 @@ from typing import Any
 import numpy as np
 from typing_extensions import Literal
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.search_space import SearchSpace
-from ..bayesian_optimization.acquisition_functions.base_acquisition import (
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
     BaseAcquisition,
 )
-from ..bayesian_optimization.acquisition_samplers.base_acq_sampler import (
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import (
     AcquisitionSampler,
 )
-from .mf_bo import MFBOBase
-from .promotion_policy import AsyncPromotionPolicy, SyncPromotionPolicy
-from .sampling_policy import (
+from neps.optimizers.multi_fidelity.mf_bo import MFBOBase
+from neps.optimizers.multi_fidelity.promotion_policy import (
+    AsyncPromotionPolicy,
+    SyncPromotionPolicy,
+)
+from neps.optimizers.multi_fidelity.sampling_policy import (
     EnsemblePolicy,
     FixedPriorPolicy,
     ModelPolicy,
     RandomUniformPolicy,
 )
-from .successive_halving import (
+from neps.optimizers.multi_fidelity.successive_halving import (
     AsynchronousSuccessiveHalving,
     SuccessiveHalving,
     SuccessiveHalvingBase,
@@ -103,7 +104,6 @@ class HyperbandBase(SuccessiveHalvingBase):
         bracket = self.sh_brackets[self.current_sh_bracket]  # type: ignore
         bracket.observed_configs = self.observed_configs.copy()
 
-
     def clear_old_brackets(self):
         """Enforces reset at each new bracket."""
         # unlike synchronous SH, the state is not reset at each rung and a configuration
@@ -132,9 +132,7 @@ class HyperbandBase(SuccessiveHalvingBase):
         # important for the global HB to run the right SH
         self._update_sh_bracket_state()
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:
@@ -215,9 +213,7 @@ class Hyperband(HyperbandBase):
         sh_bracket._handle_promotions()
         # self._handle_promotion() need not be called as it is called by load_results()
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:
@@ -396,16 +392,13 @@ class AsynchronousHyperband(HyperbandBase):
         # Since in this version, we see the full SH rung, we fix the K to max_rung
         K = self.max_rung
         bracket_probs = [
-            self.eta ** (K - s) * (K + 1) / (K - s + 1)
-            for s in range(self.max_rung + 1)
+            self.eta ** (K - s) * (K + 1) / (K - s + 1) for s in range(self.max_rung + 1)
         ]
         bracket_probs = np.array(bracket_probs) / sum(bracket_probs)
         bracket_next = np.random.choice(range(self.max_rung + 1), p=bracket_probs)
         return bracket_next
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:

--- a/neps/optimizers/multi_fidelity/sampling_policy.py
+++ b/neps/optimizers/multi_fidelity/sampling_policy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from typing import Any
 
 import numpy as np
@@ -190,7 +189,7 @@ class EnsemblePolicy(SamplingPolicy):
                 user_priors = False
 
             if inc is None:
-                inc = deepcopy(self.pipeline_space.sample_default_configuration())
+                inc = self.pipeline_space.sample_default_configuration().clone()
                 self.logger.warning(
                     "No incumbent config found, using default as the incumbent."
                 )
@@ -200,7 +199,7 @@ class EnsemblePolicy(SamplingPolicy):
                 config = self.sample_neighbour(inc, distance)
             elif self.inc_type == "gaussian":
                 # use inc to set the defaults of the configuration
-                _inc = deepcopy(inc)
+                _inc = inc.clone()
                 _inc.set_defaults_to_current_values()
                 # then sample with prior=True from that configuration
                 # since the defaults are treated as the prior

--- a/neps/optimizers/multi_fidelity/successive_halving.py
+++ b/neps/optimizers/multi_fidelity/successive_halving.py
@@ -405,7 +405,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
         if rung_to_promote is not None:
             # promotes the first recorded promotable config in the argsort-ed rung
             row = self.observed_configs.iloc[self.rung_promotions[rung_to_promote][0]]
-            config = deepcopy(row["config"])
+            config = row["config"].clone()
             rung = rung_to_promote + 1
             # assigning the fidelity to evaluate the config at
             config.fidelity.set_value(self.rung_map[rung])
@@ -504,6 +504,9 @@ class SuccessiveHalving(SuccessiveHalvingBase):
         # iterates over the different SH brackets which span start-end by index
         while end <= len(self.observed_configs):
             # for the SH bracket in start-end, calculate total SH budget used
+
+            # TODO(eddiebergman): Not idea what the type is of the stuff in the deepcopy
+            # but should work on removing the deepcopy
             bracket_budget_used = self._calc_budget_used_in_bracket(
                 deepcopy(self.observed_configs.rung.values[start:end])
             )

--- a/neps/optimizers/multi_fidelity/successive_halving.py
+++ b/neps/optimizers/multi_fidelity/successive_halving.py
@@ -10,21 +10,27 @@ import numpy as np
 import pandas as pd
 from typing_extensions import Literal
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.hyperparameters.categorical import (
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.hyperparameters.categorical import (
     CATEGORICAL_CONFIDENCE_SCORES,
     CategoricalParameter,
 )
-from ...search_spaces.hyperparameters.constant import ConstantParameter
-from ...search_spaces.hyperparameters.float import (
+from neps.search_spaces.hyperparameters.constant import ConstantParameter
+from neps.search_spaces.hyperparameters.float import (
     FLOAT_CONFIDENCE_SCORES,
     FloatParameter,
 )
-from ...search_spaces.hyperparameters.integer import IntegerParameter
-from ...search_spaces.search_space import SearchSpace
-from ..base_optimizer import BaseOptimizer
-from .promotion_policy import AsyncPromotionPolicy, SyncPromotionPolicy
-from .sampling_policy import FixedPriorPolicy, RandomUniformPolicy
+from neps.search_spaces.hyperparameters.integer import IntegerParameter
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.base_optimizer import BaseOptimizer
+from neps.optimizers.multi_fidelity.promotion_policy import (
+    AsyncPromotionPolicy,
+    SyncPromotionPolicy,
+)
+from neps.optimizers.multi_fidelity.sampling_policy import (
+    FixedPriorPolicy,
+    RandomUniformPolicy,
+)
 
 CUSTOM_FLOAT_CONFIDENCE_SCORES = FLOAT_CONFIDENCE_SCORES.copy()
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
@@ -176,9 +182,9 @@ class SuccessiveHalvingBase(BaseOptimizer):
         assert s <= self.stopping_rate_limit
         new_min_budget = self.min_budget * (self.eta**s)
         nrungs = (
-            np.floor(
-                np.log(self.max_budget / new_min_budget) / np.log(self.eta)
-            ).astype(int)
+            np.floor(np.log(self.max_budget / new_min_budget) / np.log(self.eta)).astype(
+                int
+            )
             + 1
         )
         _max_budget = self.max_budget
@@ -197,9 +203,9 @@ class SuccessiveHalvingBase(BaseOptimizer):
         assert s <= self.stopping_rate_limit
         new_min_budget = self.min_budget * (self.eta**s)
         nrungs = (
-            np.floor(
-                np.log(self.max_budget / new_min_budget) / np.log(self.eta)
-            ).astype(int)
+            np.floor(np.log(self.max_budget / new_min_budget) / np.log(self.eta)).astype(
+                int
+            )
             + 1
         )
         s_max = self.stopping_rate_limit + 1
@@ -307,7 +313,6 @@ class SuccessiveHalvingBase(BaseOptimizer):
         )
         self.rung_promotions = self.promotion_policy.retrieve_promotions()
 
-
     def clear_old_brackets(self):
         return
 
@@ -376,9 +381,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
         return config
 
     def _generate_new_config_id(self):
-        return (
-            self.observed_configs.index.max() + 1 if len(self.observed_configs) else 0
-        )
+        return self.observed_configs.index.max() + 1 if len(self.observed_configs) else 0
 
     def get_default_configuration(self):
         pass
@@ -396,9 +399,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
                 break
         return rung_to_promote
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:
@@ -426,9 +427,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
                 if self.sample_default_at_target:
                     # sets the default config to be evaluated at the target fidelity
                     rung_id = self.max_rung
-                    self.logger.info(
-                        "Next config will be evaluated at target fidelity."
-                    )
+                    self.logger.info("Next config will be evaluated at target fidelity.")
                 self.logger.info("Sampling the default configuration...")
                 config = self.pipeline_space.sample_default_configuration()
 

--- a/neps/optimizers/multi_fidelity/successive_halving.py
+++ b/neps/optimizers/multi_fidelity/successive_halving.py
@@ -11,17 +11,13 @@ import pandas as pd
 from typing_extensions import Literal
 
 from neps.utils.types import ConfigResult, RawConfig
-from neps.search_spaces.hyperparameters.categorical import (
-    CATEGORICAL_CONFIDENCE_SCORES,
+from neps.search_spaces import (
     CategoricalParameter,
-)
-from neps.search_spaces.hyperparameters.constant import ConstantParameter
-from neps.search_spaces.hyperparameters.float import (
-    FLOAT_CONFIDENCE_SCORES,
+    ConstantParameter,
     FloatParameter,
+    IntegerParameter,
+    SearchSpace
 )
-from neps.search_spaces.hyperparameters.integer import IntegerParameter
-from neps.search_spaces.search_space import SearchSpace
 from neps.optimizers.base_optimizer import BaseOptimizer
 from neps.optimizers.multi_fidelity.promotion_policy import (
     AsyncPromotionPolicy,
@@ -32,10 +28,10 @@ from neps.optimizers.multi_fidelity.sampling_policy import (
     RandomUniformPolicy,
 )
 
-CUSTOM_FLOAT_CONFIDENCE_SCORES = FLOAT_CONFIDENCE_SCORES.copy()
+CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(FloatParameter.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
-CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = CATEGORICAL_CONFIDENCE_SCORES.copy()
+CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(CategoricalParameter.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES.update({"ultra": 8})
 
 
@@ -412,7 +408,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
             config = deepcopy(row["config"])
             rung = rung_to_promote + 1
             # assigning the fidelity to evaluate the config at
-            config.fidelity.value = self.rung_map[rung]
+            config.fidelity.set_value(self.rung_map[rung])
             # updating config IDs
             previous_config_id = f"{row.name}_{rung_to_promote}"
             config_id = f"{row.name}_{rung}"
@@ -441,7 +437,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
                 config = self.sample_new_config(rung=rung_id)
 
             fidelity_value = self.rung_map[rung_id]
-            config.fidelity.value = fidelity_value
+            config.fidelity.set_value(fidelity_value)
 
             previous_config_id = None
             config_id = f"{self._generate_new_config_id()}_{rung_id}"

--- a/neps/optimizers/multi_fidelity/utils.py
+++ b/neps/optimizers/multi_fidelity/utils.py
@@ -18,7 +18,7 @@ def continuous_to_tabular(
     Convert the continuous parameters in the config into categorical ones based on
     the categorical_space provided
     """
-    result = config.copy()
+    result = config.clone()
     for hp_name, _ in config.items():
         if hp_name in categorical_space.keys():
             choices = np.array(categorical_space[hp_name].choices)

--- a/neps/optimizers/multi_fidelity/utils.py
+++ b/neps/optimizers/multi_fidelity/utils.py
@@ -25,7 +25,7 @@ def continuous_to_tabular(
             diffs = choices - config[hp_name].value
             # NOTE: in case of a tie the first value in the choices array will be returned
             closest = choices[np.abs(diffs).argmin()]
-            result[hp_name].value = closest
+            result[hp_name].set_value(closest)
 
     return result
 

--- a/neps/optimizers/multi_fidelity_prior/async_priorband.py
+++ b/neps/optimizers/multi_fidelity_prior/async_priorband.py
@@ -5,19 +5,21 @@ import typing
 import numpy as np
 from typing_extensions import Literal
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.search_space import SearchSpace
-from ..bayesian_optimization.acquisition_functions.base_acquisition import (
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
     BaseAcquisition,
 )
-from ..bayesian_optimization.acquisition_samplers.base_acq_sampler import (
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import (
     AcquisitionSampler,
 )
-from ..multi_fidelity.mf_bo import MFBOBase
-from ..multi_fidelity.promotion_policy import AsyncPromotionPolicy
-from ..multi_fidelity.sampling_policy import EnsemblePolicy, ModelPolicy
-from ..multi_fidelity.successive_halving import AsynchronousSuccessiveHalvingWithPriors
-from ..multi_fidelity_prior.priorband import PriorBandBase
+from neps.optimizers.multi_fidelity.mf_bo import MFBOBase
+from neps.optimizers.multi_fidelity.promotion_policy import AsyncPromotionPolicy
+from neps.optimizers.multi_fidelity.sampling_policy import EnsemblePolicy, ModelPolicy
+from neps.optimizers.multi_fidelity.successive_halving import (
+    AsynchronousSuccessiveHalvingWithPriors,
+)
+from neps.optimizers.multi_fidelity_prior.priorband import PriorBandBase
 
 
 class PriorBandAsha(MFBOBase, PriorBandBase, AsynchronousSuccessiveHalvingWithPriors):
@@ -119,7 +121,7 @@ class PriorBandAsha(MFBOBase, PriorBandBase, AsynchronousSuccessiveHalvingWithPr
 
     def get_config_and_ids(
         self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    ) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:
@@ -265,16 +267,13 @@ class PriorBandAshaHB(PriorBandAsha):
         # Since in this version, we see the full SH rung, we fix the K to max_rung
         K = self.max_rung
         bracket_probs = [
-            self.eta ** (K - s) * (K + 1) / (K - s + 1)
-            for s in range(self.max_rung + 1)
+            self.eta ** (K - s) * (K + 1) / (K - s + 1) for s in range(self.max_rung + 1)
         ]
         bracket_probs = np.array(bracket_probs) / sum(bracket_probs)
         bracket_next = np.random.choice(range(self.max_rung + 1), p=bracket_probs)
         return bracket_next
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:

--- a/neps/optimizers/multi_fidelity_prior/priorband.py
+++ b/neps/optimizers/multi_fidelity_prior/priorband.py
@@ -5,7 +5,7 @@ import typing
 import numpy as np
 from typing_extensions import Literal
 
-from neps.types import RawConfig
+from neps.utils.types import RawConfig
 from neps.search_spaces.search_space import SearchSpace
 from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
     BaseAcquisition,

--- a/neps/optimizers/multi_fidelity_prior/priorband.py
+++ b/neps/optimizers/multi_fidelity_prior/priorband.py
@@ -1,5 +1,3 @@
-# type: ignore
-
 from __future__ import annotations
 
 import typing
@@ -7,16 +5,19 @@ import typing
 import numpy as np
 from typing_extensions import Literal
 
-from ...search_spaces.search_space import SearchSpace
-from ..bayesian_optimization.acquisition_functions.base_acquisition import BaseAcquisition
-from ..bayesian_optimization.acquisition_samplers.base_acq_sampler import (
+from neps.types import RawConfig
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
+    BaseAcquisition,
+)
+from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler import (
     AcquisitionSampler,
 )
-from ..multi_fidelity.hyperband import HyperbandCustomDefault
-from ..multi_fidelity.mf_bo import MFBOBase
-from ..multi_fidelity.promotion_policy import SyncPromotionPolicy
-from ..multi_fidelity.sampling_policy import EnsemblePolicy, ModelPolicy
-from .utils import (
+from neps.optimizers.multi_fidelity.hyperband import HyperbandCustomDefault
+from neps.optimizers.multi_fidelity.mf_bo import MFBOBase
+from neps.optimizers.multi_fidelity.promotion_policy import SyncPromotionPolicy
+from neps.optimizers.multi_fidelity.sampling_policy import EnsemblePolicy, ModelPolicy
+from neps.optimizers.multi_fidelity_prior.utils import (
     calc_total_resources_spent,
     compute_config_dist,
     compute_scores,
@@ -371,9 +372,7 @@ class PriorBand(MFBOBase, HyperbandCustomDefault, PriorBandBase):
             sh.model_policy = self.model_policy
             sh.sample_new_config = self.sample_new_config
 
-    def get_config_and_ids(
-        self,
-    ) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         """...and this is the method that decides which point to query.
 
         Returns:

--- a/neps/optimizers/multi_fidelity_prior/utils.py
+++ b/neps/optimizers/multi_fidelity_prior/utils.py
@@ -27,8 +27,7 @@ def local_mutation(
                 continue
             kwargs = {"mutation_strategy": "local_search"}
             if isinstance(hp, CategoricalParameter):
-                confidences = {hp.value: len(hp.choices)}
-                kwargs["confidences"] = confidences
+                pass
             elif isinstance(hp, IntegerParameter) or isinstance(hp, FloatParameter):
                 kwargs["std"] = std
             _val = hp.mutate(**kwargs).value

--- a/neps/optimizers/multi_fidelity_prior/utils.py
+++ b/neps/optimizers/multi_fidelity_prior/utils.py
@@ -1,12 +1,17 @@
-from copy import deepcopy
-from typing import Union
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
 import scipy
 
-from ...search_spaces import CategoricalParameter, FloatParameter, IntegerParameter
-from ...search_spaces.search_space import SearchSpace
+from neps.search_spaces import (
+    CategoricalParameter,
+    ConstantParameter,
+    NumericalParameter,
+    Parameter,
+    GraphParameter,
+    SearchSpace,
+)
 
 
 def update_fidelity(config, fidelity):
@@ -14,29 +19,54 @@ def update_fidelity(config, fidelity):
     return config
 
 
+# TODO(eddiebergman): Previously this just ignored graphs,
+# now it will likely raise if it encounters one...
 def local_mutation(
-    config: SearchSpace, std: float = 0.25, mutation_rate: float = 0.5, patience: int = 50
+    config: SearchSpace,
+    std: float = 0.25,
+    mutation_rate: float = 0.5,
+    patience: int = 50,
+    mutate_categoricals: bool = True,
+    mutate_graphs: bool = True,
 ) -> SearchSpace:
     """Performs a local search by mutating randomly chosen hyperparameters."""
     for _ in range(patience):
-        new_config = deepcopy(config)
-        config_hp_names = list(new_config.keys())
-        for hp_name in config_hp_names:
-            hp = new_config.get(hp_name)
-            if hp.is_fidelity or np.random.uniform() > mutation_rate:
-                continue
-            kwargs = {"mutation_strategy": "local_search"}
-            if isinstance(hp, CategoricalParameter):
-                pass
-            elif isinstance(hp, IntegerParameter) or isinstance(hp, FloatParameter):
-                kwargs["std"] = std
-            _val = hp.mutate(**kwargs).value
-            hp.set_value(_val)
-        if not config.is_equal_value(new_config, include_fidelity=False):
-            # if the new config doesn't differ from the original config then regenerate
-            break
+        new_config: dict[str, Parameter] = {}
 
-    return new_config
+        for hp_name, hp in config.items():
+
+            if hp.is_fidelity or np.random.uniform() > mutation_rate:
+                new_config[hp_name] = hp.clone()
+
+            elif isinstance(hp, CategoricalParameter):
+                if mutate_categoricals:
+                    new_config[hp_name] = hp.mutate(mutation_strategy="local_search")
+                else:
+                    new_config[hp_name] = hp.clone()
+
+            elif isinstance(hp, GraphParameter):
+                if mutate_graphs:
+                    new_config[hp_name] = hp.mutate(mutation_strategy="bananas")
+                else:
+                    new_config[hp_name] = hp.clone()
+
+            elif isinstance(hp, NumericalParameter):
+                new_config[hp_name] = hp.mutate(
+                    mutation_strategy="local_search",
+                    std=std,
+                )
+            elif isinstance(hp, ConstantParameter):
+                new_config[hp_name] = hp.clone()
+
+            else:
+                raise NotImplementedError(f"Unknown hp type for {hp_name}: {type(hp)}")
+
+        # if the new config doesn't differ from the original config then regenerate
+        _new_ss = SearchSpace(**new_config)
+        if not config.is_equal_value(_new_ss, include_fidelity=False):
+            return _new_ss
+
+    return config.clone()
 
 
 def custom_crossover(
@@ -51,23 +81,23 @@ def custom_crossover(
     getting config2's value of the corresponding HP. By default, crossover rate is 50%.
     """
     for _ in range(patience):
-        child_config = deepcopy(config1)
+
+        child_config = config1.clone()
         for key, hyperparameter in config1.items():
             if not hyperparameter.is_fidelity and np.random.random() < crossover_prob:
-                # crossing over config2 values into config1
                 child_config[key].set_value(config2[key].value)
+
         if not child_config.is_equal_value(config1):
-            # breaks and returns only if the generated config is not the same
-            # thus requiring at least 1 HP to be crossed-over
-            break
-    else:
-        # fail safe check to handle edge cases where config1=config2 or
-        # config1 extremely local to config2 such that crossover fails to
-        # generate new config in a discrete (sub-)space
-        child_config = config1.sample(
-            patience=patience, user_priors=False, ignore_fidelity=True
-        )
-    return child_config
+            return SearchSpace(**child_config)
+
+    # fail safe check to handle edge cases where config1=config2 or
+    # config1 extremely local to config2 such that crossover fails to
+    # generate new config in a discrete (sub-)space
+    return config1.sample(
+        patience=patience,
+        user_priors=False,
+        ignore_fidelity=True,
+    )
 
 
 def compute_config_dist(config1: SearchSpace, config2: SearchSpace) -> float:
@@ -98,15 +128,17 @@ def compute_config_dist(config1: SearchSpace, config2: SearchSpace) -> float:
 
 
 def compute_scores(
-    config: SearchSpace, prior: SearchSpace, inc: SearchSpace
-) -> Union[float, float]:
+    config: SearchSpace,
+    prior: SearchSpace,
+    inc: SearchSpace,
+) -> tuple[float, float]:
     """Scores the config by a Gaussian around the prior and the incumbent."""
-    _prior = deepcopy(prior)
+    _prior = prior.clone()
     _prior.set_hyperparameters_from_dict(config.hp_values(), defaults=False)
     # compute the score of config if it was sampled from the prior (as the default)
     prior_score = _prior.compute_prior()
 
-    _inc = deepcopy(inc)
+    _inc = inc.clone()
     # setting the default to be the incumbent
     _inc.set_defaults_to_current_values()
     _inc.set_hyperparameters_from_dict(config.hp_values(), defaults=False)

--- a/neps/optimizers/multi_fidelity_prior/utils.py
+++ b/neps/optimizers/multi_fidelity_prior/utils.py
@@ -10,7 +10,7 @@ from ...search_spaces.search_space import SearchSpace
 
 
 def update_fidelity(config, fidelity):
-    config.fidelity.value = fidelity
+    config.fidelity.set_value(fidelity)
     return config
 
 
@@ -31,7 +31,7 @@ def local_mutation(
             elif isinstance(hp, IntegerParameter) or isinstance(hp, FloatParameter):
                 kwargs["std"] = std
             _val = hp.mutate(**kwargs).value
-            hp.value = _val
+            hp.set_value(_val)
         if not config.is_equal_value(new_config, include_fidelity=False):
             # if the new config doesn't differ from the original config then regenerate
             break
@@ -55,7 +55,7 @@ def custom_crossover(
         for key, hyperparameter in config1.items():
             if not hyperparameter.is_fidelity and np.random.random() < crossover_prob:
                 # crossing over config2 values into config1
-                child_config[key].value = config2[key].value
+                child_config[key].set_value(config2[key].value)
         if not child_config.is_equal_value(config1):
             # breaks and returns only if the generated config is not the same
             # thus requiring at least 1 HP to be crossed-over

--- a/neps/optimizers/multiple_knowledge_sources/prototype_optimizer.py
+++ b/neps/optimizers/multiple_knowledge_sources/prototype_optimizer.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.search_space import SearchSpace
-from ...utils.data_loading import read_tasks_and_dev_stages_from_disk
-from .. import BaseOptimizer
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.search_space import SearchSpace
+from neps.utils.data_loading import read_tasks_and_dev_stages_from_disk
+from neps.optimizers.base_optimizer import BaseOptimizer
 
 
 # TODO: Test if anything breaks after the recent changes
@@ -23,7 +23,7 @@ class KnowledgeSampling(BaseOptimizer):
         **optimizer_kwargs,
     ):
         super().__init__(**optimizer_kwargs)
-        self.prev_task_dev_search_space = self.pipeline_space.copy()
+        self.prev_task_dev_search_space = self.pipeline_space.clone()
         self._num_previous_configs: int = 0
         self.paths_prev_task_and_dev = paths_prev_task_and_dev
         self.prev_task_dev_results = None
@@ -50,7 +50,7 @@ class KnowledgeSampling(BaseOptimizer):
     ) -> None:
         self._num_previous_configs = len(previous_results) + len(pending_evaluations)
 
-    def get_config_and_ids(self) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         config = None
         i = self._num_previous_configs
         if i == 0:

--- a/neps/optimizers/random_search/optimizer.py
+++ b/neps/optimizers/random_search/optimizer.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from neps.utils.types import ConfigResult
-from ...search_spaces.search_space import SearchSpace
-from ..base_optimizer import BaseOptimizer
+from neps.utils.types import ConfigResult, RawConfig
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.base_optimizer import BaseOptimizer
 
 
 class RandomSearch(BaseOptimizer):
@@ -19,7 +19,7 @@ class RandomSearch(BaseOptimizer):
     ) -> None:
         self._num_previous_configs = len(previous_results) + len(pending_evaluations)
 
-    def get_config_and_ids(self) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         config = self.pipeline_space.sample(
             patience=self.patience,
             user_priors=self.use_priors,

--- a/neps/optimizers/regularized_evolution/optimizer.py
+++ b/neps/optimizers/regularized_evolution/optimizer.py
@@ -9,7 +9,7 @@ from typing import Callable
 import numpy as np
 import yaml
 
-from neps.types import RawConfig
+from neps.utils.types import RawConfig
 
 from neps.search_spaces.search_space import SearchSpace
 from neps.optimizers.base_optimizer import BaseOptimizer

--- a/neps/optimizers/regularized_evolution/optimizer.py
+++ b/neps/optimizers/regularized_evolution/optimizer.py
@@ -9,8 +9,10 @@ from typing import Callable
 import numpy as np
 import yaml
 
-from ...search_spaces.search_space import SearchSpace
-from ..base_optimizer import BaseOptimizer
+from neps.types import RawConfig
+
+from neps.search_spaces.search_space import SearchSpace
+from neps.optimizers.base_optimizer import BaseOptimizer
 
 
 class RegularizedEvolution(BaseOptimizer):
@@ -62,7 +64,7 @@ class RegularizedEvolution(BaseOptimizer):
         ]
         self.pending_evaluations = [el for el in pending_evaluations.values()]
 
-    def get_config_and_ids(self) -> tuple[SearchSpace, str, str | None]:
+    def get_config_and_ids(self) -> tuple[RawConfig, str, str | None]:
         if len(self.population) < self.population_size:
             if self.assisted:
                 if 0 == len(os.listdir(self.assisted_init_population_dir)):
@@ -75,9 +77,7 @@ class RegularizedEvolution(BaseOptimizer):
                         for _ in range(cur_population_size * 2)
                     ]
                     if self.assisted_zero_cost_proxy is not None:
-                        zero_cost_proxy_values = self.assisted_zero_cost_proxy(
-                            x=configs
-                        )  # type:  ignore[misc]
+                        zero_cost_proxy_values = self.assisted_zero_cost_proxy(x=configs)  # type:  ignore[misc]
                     else:
                         raise Exception("Zero cost proxy function is not defined!")
                     indices = np.argsort(zero_cost_proxy_values)[-cur_population_size:][
@@ -99,7 +99,7 @@ class RegularizedEvolution(BaseOptimizer):
                     self.assisted_init_population_dir / config_yaml, encoding="utf-8"
                 ) as f:
                     config_identifier = yaml.safe_load(f)
-                config = self.pipeline_space.copy()
+                config = self.pipeline_space.clone()
                 config.load_from(config_identifier)
                 os.remove(self.assisted_init_population_dir / config_yaml)
             else:

--- a/neps/runtime.py
+++ b/neps/runtime.py
@@ -798,6 +798,17 @@ def _sample_trial_from_optimizer(
     if prev_config_id is not None:
         previous = evaluated_trials[prev_config_id]
 
+    # NOTE(eddiebergman): So weirdly enough, `SearchSpace.hp_values()` will
+    # get the raw .value of everything, EXCEPT for `GraphParameter` which will
+    # just give the whole parameter. This assertion is used to check those
+    # are the only two things coming through here...
+    # This caused some nightmare to debug bug which led to a hack
+    # in the `SearchSpace.load_from()`
+    #
+    # -- from neps.search_spaces import GraphParameter, Parameter
+    # -- for k, v in config.items():
+    # --   assert isinstance(v, GraphParameter) or not isinstance(v, Parameter)
+
     time_sampled = time.time()
     return Trial(
         id=config_id,

--- a/neps/runtime.py
+++ b/neps/runtime.py
@@ -52,7 +52,6 @@ import time
 import traceback
 import warnings
 from contextlib import contextmanager
-from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -741,8 +740,6 @@ def _evaluate_config(
     )
 
     logger.info(f"Start evaluating config {config_id}")
-
-    config = deepcopy(config)
 
     # If pipeline_directory and previous_pipeline_directory are included in the
     # signature we supply their values, otherwise we simply do nothing.

--- a/neps/runtime.py
+++ b/neps/runtime.py
@@ -957,6 +957,11 @@ def launch_runtime(  # noqa: PLR0913, C901, PLR0915
                     logger.exception(e)
                     tb = traceback.format_exc()
                     report = trial.error(e, tb=tb, time_end=time.time())
+
+                    shared_state.evaluated_trials[trial.id] = report
+                    shared_state.pending_trials.pop(trial.id, None)
+                    shared_state.in_progress_trials.pop(trial.id, None)
+
                     serialize({"err": str(e), "tb": tb}, report.disk.error_file)
                     serialize(report.metadata, report.disk.metadata_file)
             else:
@@ -968,6 +973,10 @@ def launch_runtime(  # noqa: PLR0913, C901, PLR0915
                     )
 
                 with shared_state.lock(poll=_poll, timeout=_timeout):
+                    shared_state.evaluated_trials[trial.id] = report
+                    shared_state.pending_trials.pop(trial.id, None)
+                    shared_state.in_progress_trials.pop(trial.id, None)
+
                     eval_cost = report.cost
                     account_for_cost = False
                     if eval_cost is not None:

--- a/neps/search_spaces/__init__.py
+++ b/neps/search_spaces/__init__.py
@@ -3,6 +3,7 @@ from neps.search_spaces.architecture.graph_grammar import (
     GraphGrammar,
     GraphGrammarCell,
     GraphGrammarRepetitive,
+    GraphParameter,
 )
 from neps.search_spaces.hyperparameters import (
     CategoricalParameter,
@@ -27,6 +28,7 @@ __all__ = [
     "GraphGrammar",
     "GraphGrammarCell",
     "GraphGrammarRepetitive",
+    "GraphParameter",
     "IntegerParameter",
     "NumericalParameter",
     "Parameter",

--- a/neps/search_spaces/__init__.py
+++ b/neps/search_spaces/__init__.py
@@ -1,11 +1,36 @@
-from .architecture.api import ArchitectureParameter, FunctionParameter
-from .architecture.graph_grammar import (
+from neps.search_spaces.architecture.api import ArchitectureParameter, FunctionParameter
+from neps.search_spaces.architecture.graph_grammar import (
     GraphGrammar,
     GraphGrammarCell,
     GraphGrammarRepetitive,
 )
-from .hyperparameters.categorical import CategoricalParameter
-from .hyperparameters.constant import ConstantParameter
-from .hyperparameters.float import FloatParameter
-from .hyperparameters.integer import IntegerParameter
-from .hyperparameters.numerical import NumericalParameter
+from neps.search_spaces.hyperparameters import (
+    CategoricalParameter,
+    ConstantParameter,
+    FloatParameter,
+    IntegerParameter,
+    NumericalParameter,
+)
+from neps.search_spaces.parameter import (
+    MutatableParameter,
+    Parameter,
+    ParameterWithPrior,
+)
+from neps.search_spaces.search_space import SearchSpace
+
+__all__ = [
+    "ArchitectureParameter",
+    "CategoricalParameter",
+    "ConstantParameter",
+    "FloatParameter",
+    "FunctionParameter",
+    "GraphGrammar",
+    "GraphGrammarCell",
+    "GraphGrammarRepetitive",
+    "IntegerParameter",
+    "NumericalParameter",
+    "Parameter",
+    "ParameterWithPrior",
+    "MutatableParameter",
+    "SearchSpace",
+]

--- a/neps/search_spaces/architecture/core_graph_grammar.py
+++ b/neps/search_spaces/architecture/core_graph_grammar.py
@@ -118,10 +118,6 @@ class CoreGraphGrammar(Graph):
         if len(graph) == 0 or graph.number_of_edges() == 0:
             raise ValueError("Invalid DAG")
 
-    @abstractmethod
-    def get_graphs(self):
-        raise NotImplementedError
-
     def prune_tree(
         self,
         tree: nx.DiGraph,
@@ -1643,7 +1639,7 @@ class CoreGraphGrammar(Graph):
 
         return composed_function
 
-    def graph_to_self(self, graph: nx.DiGraph, clear_self: bool = True):
+    def graph_to_self(self, graph: nx.DiGraph, clear_self: bool = True) -> None:
         """Copies graph to self
 
         Args:
@@ -1658,7 +1654,7 @@ class CoreGraphGrammar(Graph):
             self.nodes[n].update(**data)
 
     def _unparse_tree(
-        self, identifier: str, grammar: Grammar, as_composition: bool = True
+        self, identifier: str, grammar: Grammar, as_composition: bool = True,
     ):
         descriptor = self.id_to_string_tree(identifier)
 

--- a/neps/search_spaces/architecture/graph_grammar.py
+++ b/neps/search_spaces/architecture/graph_grammar.py
@@ -139,13 +139,13 @@ class GraphParameter(ParameterWithPrior[nx.DiGraph, str], MutatableParameter):
         self.create_from_id(value)
 
     @abstractmethod
-    def mutate(self, parent: Self | None = None) -> Self: ...
+    def mutate(self, parent: Self | None = None, *, mutation_strategy: str = "bananas") -> Self: ...
 
     @abstractmethod
     def crossover(self, parent1: Self, parent2: Self | None = None) -> tuple[Self, Self]:
         ...
 
-    def _get_neighbours(self, num_neighbours: int) -> list[Self]:
+    def _get_non_unique_neighbors(self, num_neighbours: int) -> list[Self]:
         raise NotImplementedError
 
     def value_to_normalized(self, value: nx.DiGraph) -> float:
@@ -154,6 +154,11 @@ class GraphParameter(ParameterWithPrior[nx.DiGraph, str], MutatableParameter):
     def normalized_to_value(self, normalized_value: float) -> nx.DiGraph:
         raise NotImplementedError
 
+    @override
+    def clone(self) -> Self:
+        # NOTE(eddiebergman): We don't have any safe way better than a deepcopy
+        # I think
+        return deepcopy(self)
 
 class GraphGrammar(GraphParameter, CoreGraphGrammar):
     hp_name = "graph_grammar"

--- a/neps/search_spaces/hyperparameters/__init__.py
+++ b/neps/search_spaces/hyperparameters/__init__.py
@@ -1,0 +1,13 @@
+from neps.search_spaces.hyperparameters.categorical import CategoricalParameter
+from neps.search_spaces.hyperparameters.constant import ConstantParameter
+from neps.search_spaces.hyperparameters.float import FloatParameter
+from neps.search_spaces.hyperparameters.integer import IntegerParameter
+from neps.search_spaces.hyperparameters.numerical import NumericalParameter
+
+__all__ = [
+    "CategoricalParameter",
+    "ConstantParameter",
+    "IntegerParameter",
+    "FloatParameter",
+    "NumericalParameter",
+]

--- a/neps/search_spaces/hyperparameters/categorical.py
+++ b/neps/search_spaces/hyperparameters/categorical.py
@@ -20,7 +20,7 @@ from more_itertools import all_unique
 from neps.search_spaces.parameter import MutatableParameter, ParameterWithPrior
 
 if TYPE_CHECKING:
-    from neps.types import f64
+    from neps.utils.types import f64
 
 CategoricalTypes: TypeAlias = Union[float, int, str]
 

--- a/neps/search_spaces/hyperparameters/constant.py
+++ b/neps/search_spaces/hyperparameters/constant.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import Any, TypeVar
 from typing_extensions import Self, override
 
@@ -50,6 +49,10 @@ class ConstantParameter(Parameter[T, T]):
         super().__init__(value=value, default=value, is_fidelity=False)  # type: ignore
         self._value: T = value  # type: ignore
 
+    @override
+    def clone(self) -> Self:
+        return self.__class__(value=self.value)
+
     @property
     @override
     def value(self) -> T:
@@ -66,8 +69,8 @@ class ConstantParameter(Parameter[T, T]):
         return f"<Constant, value: {self.value}>"
 
     @override
-    def sample_value(self) -> Any:
-        return deepcopy(self.value)
+    def sample_value(self) -> T:
+        return self.value
 
     @override
     def set_default(self, default: T | None) -> None:
@@ -145,8 +148,13 @@ class ConstantParameter(Parameter[T, T]):
         return self._value
 
     @override
-    def _get_neighbours(self, num_neighbours: int, *, std: float = 0.2) -> list[Self]:
-        return []
+    def _get_non_unique_neighbors(
+        self,
+        num_neighbours: int,
+        *,
+        std: float = 0.2,
+    ) -> list[Self]:
+        raise ValueError("ConstantParameter have no neighbours")
 
     @override
     @classmethod

--- a/neps/search_spaces/hyperparameters/constant.py
+++ b/neps/search_spaces/hyperparameters/constant.py
@@ -11,7 +11,7 @@ from neps.search_spaces.parameter import Parameter
 T = TypeVar("T", int, float, str)
 
 
-class ConstantParameter(Parameter[T]):
+class ConstantParameter(Parameter[T, T]):
     """A constant value for a parameter.
 
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
@@ -147,3 +147,13 @@ class ConstantParameter(Parameter[T]):
     @override
     def _get_neighbours(self, num_neighbours: int, *, std: float = 0.2) -> list[Self]:
         return []
+
+    @override
+    @classmethod
+    def serialize_value(cls, value: T) -> T:
+        return value
+
+    @override
+    @classmethod
+    def deserialize_value(cls, value: T) -> T:
+        return value

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -89,7 +89,7 @@ class FloatParameter(NumericalParameter[float]):
             )
 
         self.default = float(default)
-        self.has_prior = default is not None
+        self.has_prior = True
         if self.log:
             self.log_default = np.log(self.default)
 
@@ -137,9 +137,6 @@ class FloatParameter(NumericalParameter[float]):
 
     @override
     def value_to_normalized(self, value: float) -> float:
-        if np.isnan(value):
-            raise ValueError("Float parameter value is NaN!")
-
         if self.log:
             assert self.log_bounds is not None
             low, high = self.log_bounds
@@ -151,9 +148,6 @@ class FloatParameter(NumericalParameter[float]):
 
     @override
     def normalized_to_value(self, normalized_value: float) -> float:
-        if np.isnan(normalized_value):
-            raise ValueError("Float parameter value is NaN!")
-
         if self.log:
             assert self.log_bounds is not None
             low, high = self.log_bounds

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -1,26 +1,25 @@
+"""Float hyperparameter for search spaces."""
+
 from __future__ import annotations
 
 import math
-from copy import deepcopy
-from typing import Literal
+from typing import TYPE_CHECKING, ClassVar, Literal, Mapping
+from typing_extensions import override
 
 import numpy as np
-import scipy.stats
 
-from .numerical import NumericalParameter
+from neps.search_spaces.hyperparameters.numerical import NumericalParameter
 
-FLOAT_CONFIDENCE_SCORES = {
-    "low": 0.5,
-    "medium": 0.25,
-    "high": 0.125,
-}
+if TYPE_CHECKING:
+    from neps.types import Number
 
 
-class FloatParameter(NumericalParameter):
+class FloatParameter(NumericalParameter[float]):
     """A float value for a parameter.
 
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
-    to represent hyperparameters with continuous float values, optionally specifying if it exists
+    to represent hyperparameters with continuous float values, optionally specifying if
+    it exists
     on a log scale.
     For example, `l2_norm` could be a value in `(0.1)`, while the `learning_rate`
     hyperparameter in a neural network search space can be a `FloatParameter`
@@ -32,16 +31,25 @@ class FloatParameter(NumericalParameter):
     l2_norm = neps.FloatParameter(0, 1)
     learning_rate = neps.FloatParameter(1e-4, 1e-1, log=True)
     ```
+
+    Please see the [`NumericalParameter`][neps.search_spaces.numerical.NumericalParameter]
+    class for more details on the methods available for this class.
     """
+
+    DEFAULT_CONFIDENCE_SCORES: ClassVar[Mapping[str, float]] = {
+        "low": 0.5,
+        "medium": 0.25,
+        "high": 0.125,
+    }
 
     def __init__(
         self,
-        lower: float | int,
-        upper: float | int,
+        lower: Number,
+        upper: Number,
         *,
         log: bool = False,
         is_fidelity: bool = False,
-        default: None | float | int = None,
+        default: Number | None = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
         """Create a new `FloatParameter`.
@@ -53,97 +61,68 @@ class FloatParameter(NumericalParameter):
             is_fidelity: whether the hyperparameter is fidelity.
             default: default value for the hyperparameter.
             default_confidence: confidence score for the default value, used when
-                condsider prior based optimization.
+                condsidering prior based optimization..
         """
-        super().__init__(is_fidelity=is_fidelity)
-
-        self.default = default
-        self.default_confidence_score = FLOAT_CONFIDENCE_SCORES[default_confidence]
-        self.has_prior = self.default is not None
-
-        self.lower = float(lower)
-        self.upper = float(upper)
-
-        if self.lower >= self.upper:
-            raise ValueError(
-                f"Float parameter: bounds error (lower >= upper). Actual values: "
-                f"lower={self.lower}, upper={self.upper}"
-            )
-
-        if self.default is not None:
-            if not self.lower <= self.default <= self.upper:
-                raise ValueError(
-                    f"Float parameter: default bounds error. Expected lower <= default"
-                    f" <= upper, but got lower={self.lower}, default={self.default},"
-                    f" upper={self.upper}"
-                )
-
-        # Validate 'log' and 'is_fidelity' types to prevent configuration errors
-        # from the YAML input
-        for param, value in {"log": log, "is_fidelity": is_fidelity}.items():
-            if not isinstance(value, bool):
-                raise TypeError(
-                    f"Expected '{param}' to be a boolean, but got type: "
-                    f"{type(value).__name__}"
-                )
-
-        self.log = log
-
-        if self.log:
-            self._set_log_values()
-
-        self.value: None | float = None
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-        return (
-            self.lower == other.lower
-            and self.upper == other.upper
-            and self.log == other.log
-            and self.is_fidelity == other.is_fidelity
-            and self.value == other.value
-            and self.default == other.default
-            and self.default_confidence_score == other.default_confidence_score
+        super().__init__(
+            lower=float(lower),
+            upper=float(upper),
+            log=log,
+            default=float(default) if default is not None else None,
+            default_confidence=default_confidence,
+            is_fidelity=is_fidelity,
         )
 
-    def __repr__(self):
-        float_repr = f"{self.value:.07f}" if self.value is not None else "None"
-        return f"<Float, range: [{self.lower}, {self.upper}], value: {float_repr}>"
+    @override
+    def set_default(self, default: float | None) -> None:
+        if default is None:
+            self.default = None
+            self.has_prior = False
+            self.log_default = None
+            return
 
-    def _set_log_values(self):
-        if self.lower <= 0:
-            raise ValueError("Float parameter: bounds error (log scale).")
-        self._lower = np.log(self.lower)
-        self._upper = np.log(self.upper)
-        if self.default is not None:
-            self._default = np.log(self.default)
-        else:
-            self._default = None
+        if not self.lower <= default <= self.upper:
+            cls_name = self.__class__.__name__
+            raise ValueError(
+                f"{cls_name} parameter: default bounds error. Expected lower <= default"
+                f" <= upper, but got lower={self.lower}, default={default},"
+                f" upper={self.upper}"
+            )
 
-    def _get_low_high_default(self):
+        self.default = float(default)
+        self.has_prior = default is not None
         if self.log:
-            self._set_log_values()
-            return self._lower, self._upper, self._default
+            self.log_default = np.log(self.default)
+
+    @override
+    def set_value(self, value: float | None) -> None:
+        if value is None:
+            self._value = None
+            self.normalized_value = None
+            self.log_value = None
+            return
+
+        if not self.lower <= value <= self.upper:
+            cls_name = self.__class__.__name__
+            raise ValueError(
+                f"{cls_name} parameter: default bounds error. Expected lower <= default"
+                f" <= upper, but got lower={self.lower}, value={value},"
+                f" upper={self.upper}"
+            )
+
+        value = float(value)
+        self._value = value
+        self.normalized_value = self.value_to_normalized(value)
+        if self.log:
+            self.log_value = np.log(value)
+
+    @override
+    def sample_value(self, *, user_priors: bool = False) -> float:
+        if self.log:
+            assert self.log_bounds is not None
+            low, high = self.log_bounds
+            default = self.log_default
         else:
-            return self.lower, self.upper, self.default
-
-    def _get_truncnorm_prior_and_std(self):
-        low, high, default = self._get_low_high_default()
-        std = (high - low) * self.default_confidence_score
-        a, b = (low - default) / std, (high - default) / std
-        return scipy.stats.truncnorm(a, b), std
-
-    def compute_prior(self, log: bool = False):
-        _, _, default = self._get_low_high_default()
-        value = np.log(self.value) if self.log else self.value
-        value -= default
-        dist, std = self._get_truncnorm_prior_and_std()
-        value /= std
-        return np.log(dist.pdf(value) + 1e-12) if log else dist.pdf(value)
-
-    def sample(self, user_priors: bool = False):
-        low, high, default = self._get_low_high_default()
+            low, high, default = self.lower, self.upper, self.default
 
         if user_priors and self.has_prior:
             dist, std = self._get_truncnorm_prior_and_std()
@@ -154,96 +133,36 @@ class FloatParameter(NumericalParameter):
         if self.log:
             value = math.exp(value)
 
-        self.value = min(self.upper, max(self.lower, value))
+        return float(min(self.upper, max(self.lower, value)))
 
-    def mutate(
-        self,
-        parent=None,
-        mutation_rate: float = 1.0,
-        mutation_strategy: str = "local_search",
-        **kwargs,
-    ):
-        if self.is_fidelity:
-            raise ValueError("Trying to mutate fidelity param!")
-        if parent is None:
-            parent = self
+    @override
+    def value_to_normalized(self, value: float) -> float:
+        if np.isnan(value):
+            raise ValueError("Float parameter value is NaN!")
 
-        if mutation_strategy == "simple":
-            child = deepcopy(self)
-            child.sample()
-        elif mutation_strategy == "local_search":
-            if "std" in kwargs:
-                child = self._get_neighbours(std=kwargs["std"], num_neighbours=1)[
-                    0
-                ]
-            else:
-                child = self._get_neighbours(num_neighbours=1)[
-                    0
-                ]
+        if self.log:
+            assert self.log_bounds is not None
+            low, high = self.log_bounds
         else:
-            raise NotImplementedError
+            low, high = self.lower, self.upper
 
-        if parent.value == child.value:
-            raise ValueError("Parent is the same as child!")
+        value = np.log(value) if self.log else value
+        return float((value - low) / (high - low))
 
-        # child.value = min(1.0, max(0.0, child.value))
-        return child
-
-    def crossover(self, parent1, parent2=None):
-        if self.is_fidelity:
-            raise ValueError("Trying to crossover fidelity param!")
-        if parent2 is None:
-            parent2 = self
-
-        proxy_self = deepcopy(self)
-        proxy_self.value = (parent1.value + parent2.value) / 2
-        children = proxy_self._get_neighbours(std=0.1, num_neighbours=2)
-
-        if all(not c for c in children):
-            raise Exception("Cannot create crossover")
-        # expected len(children) == num_neighbours
-        return children
-
-    def _get_neighbours(self, std: float = 0.2, num_neighbours: int = 1):
-        neighbours: list[FloatParameter] = []
-        cur_value = self._normalize_value(self.value)
-
-        while len(neighbours) < num_neighbours:
-            n_val = np.random.normal(cur_value, std)
-            if n_val < 0 or n_val > 1:
-                continue
-            neighbour = deepcopy(self)
-            neighbour.value = neighbour._normalization_inv(n_val)
-            neighbours.append(neighbour)
-
-        return neighbours
-
-    def _normalize_value(self, value):
-        if value != value:
+    @override
+    def normalized_to_value(self, normalized_value: float) -> float:
+        if np.isnan(normalized_value):
             raise ValueError("Float parameter value is NaN!")
 
-        if value is not None:
-            low, up, _ = self._get_low_high_default()
-            value = np.log(value) if self.log else value
-            return (value - low) / (up - low)
+        if self.log:
+            assert self.log_bounds is not None
+            low, high = self.log_bounds
+        else:
+            low, high = self.lower, self.upper
 
-    def _normalization_inv(self, value):
-        if value != value:
-            raise ValueError("Float parameter value is NaN!")
+        normalized_value = normalized_value * (high - low) + low
+        return np.exp(normalized_value) if self.log else normalized_value
 
-        if value is not None:
-            low, up, _ = self._get_low_high_default()
-            value = value * (up - low) + low
-            return np.exp(value) if self.log else value
-
-    def normalized(self):
-        hp = super().normalized()
-        hp.value = self._normalize_value(self.value)
-        hp.default = self._normalize_value(self.default)
-        hp.low = 0
-        hp.high = 1
-        hp.log = False
-        return hp
-
-    def set_default_confidence_score(self, default_confidence):
-        self.default_confidence_score = FLOAT_CONFIDENCE_SCORES[default_confidence]
+    def __repr__(self) -> str:
+        float_repr = f"{self.value:.07f}" if self.value is not None else "None"
+        return f"<Float, range: [{self.lower}, {self.upper}], value: {float_repr}>"

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -11,7 +11,7 @@ import numpy as np
 from neps.search_spaces.hyperparameters.numerical import NumericalParameter
 
 if TYPE_CHECKING:
-    from neps.types import Number
+    from neps.utils.types import Number
 
 
 class FloatParameter(NumericalParameter[float]):

--- a/neps/search_spaces/hyperparameters/integer.py
+++ b/neps/search_spaces/hyperparameters/integer.py
@@ -132,8 +132,6 @@ class IntegerParameter(NumericalParameter[int]):
             self.float_hp.set_value(None)
             return
 
-        value = int(np.rint(value))
-
         if not self.lower <= value <= self.upper:
             cls_name = self.__class__.__name__
             raise ValueError(
@@ -141,6 +139,8 @@ class IntegerParameter(NumericalParameter[int]):
                 f" <= upper, but got lower={self.lower}, value={value},"
                 f" upper={self.upper}"
             )
+
+        value = int(np.rint(value))
 
         self.float_hp.set_value(value)
         self._value = value

--- a/neps/search_spaces/hyperparameters/integer.py
+++ b/neps/search_spaces/hyperparameters/integer.py
@@ -90,10 +90,12 @@ class IntegerParameter(NumericalParameter[int]):
     def set_default(self, default: int | None) -> None:
         if default is None:
             self.default = None
+            self.has_prior = False
             self.float_hp.set_default(None)
         else:
             _default = int(round(default))
             self.default = _default
+            self.has_prior = True
             self.float_hp.set_default(_default)
 
     @override

--- a/neps/search_spaces/hyperparameters/integer.py
+++ b/neps/search_spaces/hyperparameters/integer.py
@@ -11,7 +11,7 @@ from neps.search_spaces.hyperparameters.float import FloatParameter
 from neps.search_spaces.hyperparameters.numerical import NumericalParameter
 
 if TYPE_CHECKING:
-    from neps.types import Number
+    from neps.utils.types import Number
 
 
 class IntegerParameter(NumericalParameter[int]):

--- a/neps/search_spaces/hyperparameters/numerical.py
+++ b/neps/search_spaces/hyperparameters/numerical.py
@@ -1,23 +1,304 @@
-from abc import abstractmethod
+"""The [`NumericalParameter`][neps.search_spaces.NumericalParameter] is
+a [`Parameter`][neps.search_spaces.Parameter] that represents a numerical
+range.
 
-from ..parameter import Parameter
+The two primary numerical hyperparameters are:
+
+* [`FloatParameter`][neps.search_spaces.FloatParameter] for continuous
+    float values.
+* [`IntegerParameter`][neps.search_spaces.IntegerParameter] for discrete
+    integer values.
+
+The [`NumericalParameter`][neps.search_spaces.NumericalParameter] is a
+base class for both of these hyperparameters, and includes methods from
+both [`ParameterWithPrior`][neps.search_spaces.ParameterWithPrior],
+allowing you to set a confidence along with a
+[`.default`][neps.search_spaces.Parameter.default] that can be used
+with certain algorithms, as well as
+[`MutatableParameter`][neps.search_spaces.MutatableParameter],
+which allows for [`mutate()`][neps.search_spaces.NumericalParameter.mutate]
+and [`crossover()`][neps.search_spaces.NumericalParameter.crossover] operations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Mapping, TypeVar
+from typing_extensions import Self, override
+
+import numpy as np
+import scipy
+
+from neps.search_spaces.parameter import MutatableParameter, ParameterWithPrior
+
+if TYPE_CHECKING:
+    from neps.search_spaces.hyperparameters.float import FloatParameter
+    from neps.search_spaces.hyperparameters.integer import IntegerParameter
+    from neps.types import TruncNorm
+
+T = TypeVar("T", int, float)
 
 
-class NumericalParameter(Parameter):
-    def __init__(self, value=None, **kwargs):
-        super().__init__(**kwargs)
-        self.value = value
+class NumericalParameter(ParameterWithPrior[T], MutatableParameter):
+    """A numerical hyperparameter is bounded by a lower and upper value.
 
-    @property
-    def id(self):
-        return self.value
+    Attributes:
+        lower: The lower bound of the numerical hyperparameter.
+        upper: The upper bound of the numerical hyperparameter.
+        log: Whether the hyperparameter is in log space.
+        log_value: The log value of the hyperparameter, if `log=True`.
+        log_bounds: The log bounds of the hyperparameter, if `log=True`.
+        log_default: The log default value of the hyperparameter, if `log=True`
+            and a `default` is set.
+        default_confidence_choice: The default confidence choice.
+        default_confidence_score: The default confidence score.
+        has_prior: Whether the hyperparameter has a prior.
+    """
 
-    @abstractmethod
-    def _get_neighbours(self):
-        raise NotImplementedError
+    DEFAULT_CONFIDENCE_SCORES: ClassVar[Mapping[str, float]]
 
-    def serialize(self):
-        return self.value
+    def __init__(
+        self,
+        lower: T,
+        upper: T,
+        *,
+        log: bool = False,
+        default: T | None,
+        is_fidelity: bool,
+        default_confidence: Literal["low", "medium", "high"] = "low",
+    ):
+        """Initialize the numerical hyperparameter.
 
-    def load_from(self, value):
-        self.value = value
+        Args:
+            lower: The lower bound of the numerical hyperparameter.
+            upper: The upper bound of the numerical hyperparameter.
+            log: Whether the hyperparameter is in log space.
+            default: The default value of the hyperparameter.
+            is_fidelity: Whether the hyperparameter is a fidelity parameter.
+            default_confidence: The default confidence choice.
+        """
+        super().__init__(value=None, default=default, is_fidelity=is_fidelity)  # type: ignore
+        _cls_name = self.__class__.__name__
+        if lower >= upper:
+            raise ValueError(
+                f"{_cls_name} parameter: bounds error (lower >= upper). Actual values: "
+                f"lower={lower}, upper={upper}"
+            )
+
+        if log and (lower <= 0 or upper <= 0):
+            raise ValueError(
+                f"{_cls_name} parameter: bounds error (log scale cant have bounds <= 0)."
+                f" Actual values: lower={lower}, upper={upper}"
+            )
+
+        if default is not None and not lower <= default <= upper:
+            raise ValueError(
+                f"Float parameter: default bounds error. Expected lower <= default"
+                f" <= upper, but got lower={lower}, default={default},"
+                f" upper={upper}"
+            )
+
+        if default_confidence not in self.DEFAULT_CONFIDENCE_SCORES:
+            raise ValueError(
+                f"{_cls_name} parameter: default confidence score error. Expected one of "
+                f"{list(self.DEFAULT_CONFIDENCE_SCORES.keys())}, but got "
+                f"{default_confidence}"
+            )
+
+        # Validate 'log' and 'is_fidelity' types to prevent configuration errors
+        # from the YAML input
+        for param, value in {"log": log, "is_fidelity": is_fidelity}.items():
+            if not isinstance(value, bool):
+                raise TypeError(
+                    f"Expected '{param}' to be a boolean, but got type: "
+                    f"{type(value).__name__}"
+                )
+
+        self.lower: T = lower
+        self.upper: T = upper
+        self.log: bool = log
+        self.log_value: float | None = None
+        self.log_bounds: tuple[float, float] | None = None
+        self.log_default: float | None = None
+        if self.log:
+            self.log_bounds = (float(np.log(lower)), float(np.log(upper)))
+            self.log_default = (
+                float(np.log(self.default)) if self.default is not None else None
+            )
+
+        self.default_confidence_choice: Literal["low", "medium", "high"] = (
+            default_confidence
+        )
+
+        self.default_confidence_score: float = self.DEFAULT_CONFIDENCE_SCORES[
+            default_confidence
+        ]
+        self.has_prior: bool = self.default is not None
+
+    @override
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+
+        return (
+            self.lower == other.lower
+            and self.upper == other.upper
+            and self.log == other.log
+            and self.is_fidelity == other.is_fidelity
+            and self.value == other.value
+            and self.default == other.default
+            and self.default_confidence_score == other.default_confidence_score
+        )
+
+    # TODO(eddiebergman): Right now this is identical for both float and integer
+    # however the integer version is buggy as it returns duplicates due to rounding
+    # Likely need to move this down to subclasses when addressed.
+    @override
+    def _get_neighbours(self, num_neighbours: int, *, std: float = 0.2) -> list[Self]:
+        neighbours: list[Self] = []
+
+        assert self.value is not None
+        vectorized_val = self.value_to_normalized(self.value)
+
+        # TODO(eddiebergman): This whole thing can be vectorized, not sure
+        # if we ever have enough num_neighbours to make it worth it
+        while len(neighbours) < num_neighbours:
+            n_val = np.random.normal(vectorized_val, std)
+            if n_val < 0 or n_val > 1:
+                continue
+
+            sampled_value = self.normalized_to_value(n_val)
+
+            neighbour = self.clone()
+            neighbour.set_value(sampled_value)
+            neighbours.append(neighbour)
+
+        return neighbours
+
+    @override
+    def compute_prior(self, *, log: bool = False) -> float:
+        default = self.log_default if self.log else self.default
+
+        assert self.value is not None
+        assert default is not None
+
+        value = np.log(self.value) if self.log else self.value
+        value -= default
+        dist, std = self._get_truncnorm_prior_and_std()
+        value /= std
+        prior = np.log(dist.pdf(value) + 1e-12) if log else dist.pdf(value)
+        return float(prior)
+
+    @override
+    def mutate(
+        self,
+        parent: Self | None = None,
+        mutation_rate: float = 1.0,
+        mutation_strategy: str = "local_search",
+        **kwargs: Any,
+    ) -> Self:
+        if self.is_fidelity:
+            raise ValueError("Trying to mutate fidelity param!")
+
+        if parent is None:
+            parent = self
+
+        if mutation_strategy == "simple":
+            child = self.clone()
+            child.sample()
+        elif mutation_strategy == "local_search" and "std" in kwargs:
+            child = self._get_neighbours(std=kwargs["std"], num_neighbours=1)[0]
+        elif mutation_strategy == "local_search":
+            child = self._get_neighbours(num_neighbours=1)[0]
+        else:
+            raise NotImplementedError
+
+        if parent.value == child.value:
+            raise ValueError("Parent is the same as child!")
+
+        return child
+
+    @override
+    def crossover(self, parent1: Self, parent2: Self | None = None) -> tuple[Self, Self]:
+        if self.is_fidelity:
+            raise ValueError("Trying to crossover fidelity param!")
+
+        if parent2 is None:
+            parent2 = self
+
+        assert parent1.value is not None
+        assert parent2.value is not None
+
+        crossover_value = (parent1.value + parent2.value) / 2
+
+        proxy_self = self.clone()
+        proxy_self.set_value(crossover_value)  # type: ignore
+
+        tt = tuple(proxy_self._get_neighbours(std=0.1, num_neighbours=2))
+        assert len(tt) == 2
+        return tt
+
+    def _get_truncnorm_prior_and_std(self) -> tuple[TruncNorm, float]:
+        if self.log:
+            assert self.log_bounds is not None
+            low, high = self.log_bounds
+            default = self.log_default
+        else:
+            low, high = self.lower, self.upper
+            default = self.default
+
+        assert default is not None
+
+        std = (high - low) * self.default_confidence_score
+        a, b = (low - default) / std, (high - default) / std
+        return scipy.stats.truncnorm(a, b), float(std)
+
+    def to_integer(self) -> IntegerParameter:
+        """Convert the numerical hyperparameter to an integer hyperparameter."""
+        from neps.search_spaces.hyperparameters.integer import IntegerParameter
+
+        as_int = lambda x: int(np.rint(x))
+
+        int_hp = IntegerParameter(
+            lower=as_int(self.lower),
+            upper=as_int(self.upper),
+            is_fidelity=self.is_fidelity,
+            default=as_int(self.default) if self.default is not None else None,
+            default_confidence=self.default_confidence_choice,  # type: ignore
+        )
+        int_hp.set_value(as_int(self.value) if self.value is not None else None)
+        return int_hp
+
+    def to_float(self) -> FloatParameter:
+        """Convert the numerical hyperparameter to a float hyperparameter."""
+        from neps.search_spaces.hyperparameters.integer import FloatParameter
+
+        float_hp = FloatParameter(
+            lower=float(self.lower),
+            upper=float(self.upper),
+            is_fidelity=self.is_fidelity,
+            default=float(self.default) if self.default is not None else None,
+            default_confidence=self.default_confidence_choice,  # type: ignore
+        )
+        float_hp.set_value(float(self.value) if self.value is not None else None)
+        return float_hp
+
+    def grid(self, *, size: int, include_endpoint: bool = True) -> list[T]:
+        """Generate a grid of values for the numerical hyperparameter.
+
+        !!! note "Duplicates"
+
+            The grid may contain duplicates if the hyperparameter is an integer,
+            for example if the lower bound is `0` and the upper bound is `10`, but
+            `size=20`.
+
+        Args:
+            size: The number of values to generate.
+            include_endpoint: Whether to include the upper bound in the grid.
+
+        Returns:
+            A list of values for the numerical hyperparameter.
+        """
+        return [
+            self.normalized_to_value(x)
+            for x in np.linspace(0, 1, num=size, endpoint=include_endpoint)
+        ]

--- a/neps/search_spaces/hyperparameters/numerical.py
+++ b/neps/search_spaces/hyperparameters/numerical.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 T = TypeVar("T", int, float)
 
 
-class NumericalParameter(ParameterWithPrior[T], MutatableParameter):
+class NumericalParameter(ParameterWithPrior[T, T], MutatableParameter):
     """A numerical hyperparameter is bounded by a lower and upper value.
 
     Attributes:
@@ -302,3 +302,13 @@ class NumericalParameter(ParameterWithPrior[T], MutatableParameter):
             self.normalized_to_value(x)
             for x in np.linspace(0, 1, num=size, endpoint=include_endpoint)
         ]
+
+    @override
+    @classmethod
+    def serialize_value(cls, value: T) -> T:
+        return value
+
+    @override
+    @classmethod
+    def deserialize_value(cls, value: T) -> T:
+        return value

--- a/neps/search_spaces/hyperparameters/numerical.py
+++ b/neps/search_spaces/hyperparameters/numerical.py
@@ -33,7 +33,7 @@ from neps.search_spaces.parameter import MutatableParameter, ParameterWithPrior
 if TYPE_CHECKING:
     from neps.search_spaces.hyperparameters.float import FloatParameter
     from neps.search_spaces.hyperparameters.integer import IntegerParameter
-    from neps.types import TruncNorm
+    from neps.utils.types import TruncNorm
 
 T = TypeVar("T", int, float)
 

--- a/neps/search_spaces/parameter.py
+++ b/neps/search_spaces/parameter.py
@@ -1,39 +1,302 @@
-from abc import abstractmethod
+"""The base [`Parameter`][neps.search_spaces.Parameter] class.
+
+The `Parameter` refers to both the hyperparameter definition but also
+holds a [`.value`][neps.search_spaces.Parameter.value] which can be
+set or empty, in which case it is `None`.
+
+!!! tip
+
+    A `Parameter` which allows for mutations and crossovers should implement
+    the [`MutatableParameter`][neps.search_spaces.MutatableParameter] protocol.
+
+!!! tip
+
+    A `Parameter` which allows for defining a
+    [`.default`][neps.search_spaces.Parameter.default] and some prior,
+    i.e. some default value along with a confidence that this is a good setting,
+    should implement the [`ParameterWithPrior`][neps.search_spaces.ParameterWithPrior]
+    class.
+
+    This is utilized by certain optimization routines to inform the search process.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
 from copy import deepcopy
+from typing import Any, ClassVar, Generic, Mapping, TypeVar, runtime_checkable
+from typing_extensions import Protocol, Self
+
+T = TypeVar("T")
 
 
-class Parameter:
-    def __init__(self, is_fidelity=False, set_default_value=True):
+class Parameter(ABC, Generic[T]):
+    """A base class for hyperparameters.
+
+    Attributes:
+        default: default value for the hyperparameter. This value
+            is used as a prior to inform algorithms about a decent
+            default value for the hyperparameter, as well as use
+            attributes from [`ParameterWithPrior`][neps.search_spaces.ParameterWithPrior],
+            to aid in optimization.
+        is_fidelity: whether the hyperparameter is fidelity.
+        value: value for the hyperparameter, if any.
+        normalized_value: normalized value for the hyperparameter.
+    """
+
+    def __init__(
+        self,
+        *,
+        value: T | None,
+        default: T | None,
+        is_fidelity: bool,
+    ):
+        """Create a new `Parameter`.
+
+        Args:
+            value: value for the hyperparameter.
+            default: default value for the hyperparameter.
+            is_fidelity: whether the hyperparameter is fidelity.
+        """
+        self.default = default
         self.is_fidelity = is_fidelity
-        if set_default_value:
-            self.value = None
 
-    @abstractmethod
-    def sample(self):
-        raise NotImplementedError
+        # TODO(eddiebergman): The reason to have this not as a straight alone
+        # attribute is that the graph parameters currently expose there own
+        # way of calculating a value on demand.
+        # To fix this would mean to essentially decouple GraphParameter entirely
+        # from Parameter as it's less of a heirarchy and more of just a small overlap
+        # of functionality.
+        self._value = value
+        self.normalized_value = (
+            self.value_to_normalized(value) if value is not None else None
+        )
 
-    @abstractmethod
-    def mutate(self, parent=None):
-        raise NotImplementedError
-
-    @abstractmethod
-    def crossover(self, parent1, parent2=None):
-        raise NotImplementedError
-
-    @abstractmethod
-    def serialize(self):
-        raise NotImplementedError
-
-    @abstractmethod
-    def load_from(self, data):
-        raise NotImplementedError
-
-    def normalized(self):
-        return deepcopy(self)
-
-    def compute_prior(self):
-        return 1
-
-    def __eq__(self, other):
+    # TODO(eddiebergman): All this does is just check values which highly unlikely
+    # what we want. However this needs to be tackled in a seperate PR.
+    #
+    # > The Princess is in another castle.
+    #
+    def __eq__(self, other: Any) -> bool:
         # Assuming that two different classes should represent two different parameters
         return isinstance(other, self.__class__) and self.serialize() == other.serialize()
+
+    # TODO(eddiebergman): The reason to use the word `clone()` instead of `copy()`
+    # is so we can find it throughout the codebase if we migrate away from copies.
+    def clone(self) -> Self:
+        """Create a deep copy of the `Parameter`."""
+        return deepcopy(self)
+
+    @property
+    def value(self) -> T | None:
+        """Get the value of the hyperparameter, or `None` if not set."""
+        return self._value
+
+    def sample(self) -> Self:
+        """Sample a new version of this `Parameter` with a random value.
+
+        Will set the [`.value`][neps.search_spaces.Parameter.value] to the
+        sampled value.
+
+        Returns:
+            A new `Parameter` with a sampled value.
+        """
+        value = self.sample_value()
+        copy_self = deepcopy(self)
+        copy_self.set_value(value)
+        return copy_self
+
+    @abstractmethod
+    def sample_value(self) -> T:
+        """Sample a new value."""
+
+    @abstractmethod
+    def set_default(self, default: T | None) -> None:
+        """Set the default value for the hyperparameter.
+
+        The `default=` is used as a prior and used to inform
+        algorithms about a decent default value for the hyperparameter.
+
+        Args:
+            default: default value for the hyperparameter.
+        """
+
+    @abstractmethod
+    def set_value(self, value: T | None) -> None:
+        """Set the value for the hyperparameter.
+
+        Args:
+            value: value for the hyperparameter.
+        """
+
+    @abstractmethod
+    def value_to_normalized(self, value: T) -> float:
+        """Convert a value to a normalized value.
+
+        Normalization is different per hyperparameter type,
+        but roughly refers to numeric values.
+
+        * `(0, 1)` scaling in the case of
+            a [`NumericalParameter`][neps.search_spaces.NumericalParameter],
+        * `{0.0, 1.0}` for a [`ConstantParameter`][neps.search_spaces.ConstantParameter],
+        * `[0, 1, ..., n]` for a
+            [`Categorical`][neps.search_spaces.CategoricalParameter].
+
+        Args:
+            value: value to convert.
+
+        Returns:
+            The normalized value.
+        """
+
+    @abstractmethod
+    def normalized_to_value(self, normalized_value: float) -> T:
+        """Convert a normalized value back to value in the defined hyperparameter range.
+
+        Args:
+            normalized_value: normalized value to convert.
+
+        Returns:
+            The value.
+        """
+
+    @abstractmethod
+    def _get_neighbours(self, num_neighbours: int, *, std: float = 0.2) -> list[Self]: ...
+
+    def serialize(self) -> T | None:
+        """Ensure the hyperparameter value is in a serializable format.
+
+
+        Returns:
+            A serializable version of the hyperparameter value, or `None`
+            if it was not set.
+        """
+        return self.value
+
+    def load_from(self, value: T) -> None:
+        """Load a serialized value into the hyperparameter's value.
+
+        Args:
+            value: value to load.
+        """
+        self._value = value
+
+
+class ParameterWithPrior(Parameter[T]):
+    """A base class for hyperparameters with priors.
+
+    Attributes:
+        default_confidence_choice: The choice of how confident any algorithm should
+            be in the default value being a good value.
+        default_confidence_score: A score used by algorithms to utilize the default value.
+        has_prior: whether the hyperparameter has a prior that can be used by an
+            algorithm. In many cases, this refers to having a default value.
+    """
+
+    DEFAULT_CONFIDENCE_SCORES: ClassVar[Mapping[str, float]]
+    default_confidence_choice: str
+    default_confidence_score: float
+    has_prior: bool
+
+    @abstractmethod
+    def compute_prior(self, *, log: bool = True) -> float:
+        """Compute the likelihood of the currently set value from
+        the sampling distribution of the hyperparameter.
+
+        Args:
+            log: whether to return the log likelihood.
+        """
+
+    # NOTE(eddiebergman): Like the normal `Parameter.sample` but with `user_priors`.
+    @abstractmethod
+    def sample_value(self, *, user_priors: bool = False) -> T:
+        """Sample a new value.
+
+        Similar to
+        [`Parameter.sample_value()`][neps.search_spaces.Parameter.sample_value],
+        but a `ParameterWithPrior` can use the confidence score by setting
+        `user_priors=True`.
+
+        Args:
+            user_priors: whether to use the confidence score
+                when sampling a value.
+
+        Returns:
+            The sampled value.
+        """
+
+    def set_default_confidence_score(self, default_confidence: str) -> None:
+        """Set the default confidence score for the hyperparameter.
+
+        Args:
+            default_confidence: the choice of how confident any algorithm should
+                be in the default value being a good value.
+
+        Raises:
+            ValueError: if the confidence score is not a valid choice.
+        """
+        if default_confidence not in self.DEFAULT_CONFIDENCE_SCORES:
+            cls_name = self.__class__.__name__
+            raise ValueError(
+                f"Invalid default confidence score: {default_confidence}"
+                f" for {cls_name}. Expected one of:"
+                f" {list(self.DEFAULT_CONFIDENCE_SCORES.keys())}"
+            )
+
+        self.default_confidence_score = self.DEFAULT_CONFIDENCE_SCORES[default_confidence]
+
+    def sample(self, *, user_priors: bool = False) -> Self:
+        """Sample a new version of this `Parameter` with a random value.
+
+        Similar to
+        [`Parameter.sample()`][neps.search_spaces.Parameter.sample],
+        but a `ParameterWithPrior` can use the confidence score by setting
+        `user_priors=True`.
+
+        Args:
+            user_priors: whether to use the confidence score
+                when sampling a value.
+
+        Returns:
+            A new `Parameter` with a sampled value.
+        """
+        value = self.sample_value(user_priors=user_priors)
+        copy_self = deepcopy(self)
+        copy_self.set_value(value)
+        return copy_self
+
+
+@runtime_checkable
+class MutatableParameter(Protocol):
+    """A protocol for hyperparameters that can be mutated.
+
+    Particpating parameters must implement the
+    [`mutate()`][neps.search_spaces.MutatableParameter.mutate] method
+    and the [`crossover()`][neps.search_spaces.MutatableParameter.crossover]
+    method.
+    """
+
+    def mutate(self, parent: Self | None = None) -> Self:
+        """Mutate the hyperparameter.
+
+        Args:
+            parent: the parent hyperparameter to mutate from.
+
+        Returns:
+            The mutated hyperparameter.
+        """
+        ...
+
+    def crossover(self, parent1: Self, parent2: Self | None = None) -> tuple[Self, Self]:
+        """Crossover the hyperparameter with another hyperparameter.
+
+        Args:
+            parent1: the first parent hyperparameter.
+            parent2: the second parent hyperparameter.
+                If left as `None`, this hyperparameter will be used as the second parent
+                to crossover with.
+
+        Returns:
+            A tuple of the two crossovered hyperparameters.
+        """
+        ...

--- a/neps/search_spaces/search_space.py
+++ b/neps/search_spaces/search_space.py
@@ -29,7 +29,7 @@ from neps.search_spaces.yaml_search_space_utils import (
     SearchSpaceFromYamlFileError,
     deduce_and_validate_param_type,
 )
-from neps.types import NotSet, _NotSet
+from neps.utils.types import NotSet, _NotSet
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/neps/search_spaces/search_space.py
+++ b/neps/search_spaces/search_space.py
@@ -1,39 +1,63 @@
+"""Contains the [`SearchSpace`][neps.search_spaces.search_space.SearchSpace] class
+which is a container for hyperparameters that can be sampled, mutated, and crossed over.
+"""
+
 from __future__ import annotations
 
+import logging
+import operator
 import pprint
-import random
-from collections import OrderedDict
 from copy import deepcopy
 from itertools import product
 from pathlib import Path
-from typing import Mapping, Any, Iterator
+from typing import TYPE_CHECKING, Any, Hashable, Iterator, Literal, Mapping
+from typing_extensions import Self
 
 import ConfigSpace as CS
 import numpy as np
-import pandas as pd
 import yaml
 
-from ..utils.common import has_instance
-from . import (
+from neps.search_spaces.architecture.graph_grammar import GraphParameter
+from neps.search_spaces.hyperparameters import (
     CategoricalParameter,
     ConstantParameter,
     FloatParameter,
     IntegerParameter,
     NumericalParameter,
 )
-from .architecture.graph import Graph
-from neps.search_spaces.parameter import Parameter
-from .yaml_search_space_utils import (
+from neps.search_spaces.parameter import MutatableParameter, Parameter, ParameterWithPrior
+from neps.search_spaces.yaml_search_space_utils import (
     SearchSpaceFromYamlFileError,
     deduce_and_validate_param_type,
 )
+from neps.types import NotSet, _NotSet
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def pipeline_space_from_configspace(
     configspace: CS.ConfigurationSpace,
 ) -> dict[str, Parameter]:
-    pipeline_space = dict()
+    """Constructs the [`Parameter`][neps.search_spaces.parameter.Parameter] objects
+    from a [`ConfigurationSpace`][ConfigSpace.configuration_space.ConfigurationSpace].
+
+    Args:
+        configspace: The configuration space to construct the pipeline space from.
+
+    Returns:
+        A dictionary where keys are parameter names and values are parameter objects.
+    """
+    pipeline_space = {}
     parameter: Parameter
+    if any(configspace.get_conditions()) or any(configspace.get_forbiddens()):
+        raise NotImplementedError(
+            "The ConfigurationSpace has conditions or forbidden clauses, "
+            "which are not supported by neps."
+        )
+
     for hyperparameter in configspace.get_hyperparameters():
         if isinstance(hyperparameter, CS.Constant):
             parameter = ConstantParameter(value=hyperparameter.value)
@@ -67,13 +91,8 @@ def pipeline_space_from_configspace(
     return pipeline_space
 
 
-def pipeline_space_from_yaml(
-    yaml_file_path: str | Path,
-) -> dict[
-    str, FloatParameter | IntegerParameter | CategoricalParameter | ConstantParameter
-]:
-    """
-    Reads configuration details from a YAML file and constructs a pipeline space
+def pipeline_space_from_yaml(yaml_file_path: str | Path) -> dict[str, Parameter]:
+    """Reads configuration details from a YAML file and constructs a pipeline space
     dictionary.
 
     This function extracts parameter configurations from a YAML file, validating and
@@ -108,10 +127,11 @@ def pipeline_space_from_yaml(
         To use this function with a YAML file 'config.yaml', you can do:
         pipeline_space = pipeline_space_from_yaml('config.yaml')
     """
+    yaml_file_path = Path(yaml_file_path)
     try:
         # try to load the YAML file
         try:
-            with open(yaml_file_path) as file:
+            with yaml_file_path.open("r") as file:
                 config = yaml.safe_load(file)
         except FileNotFoundError as e:
             raise FileNotFoundError(
@@ -121,11 +141,11 @@ def pipeline_space_from_yaml(
             ) from e
         except yaml.YAMLError as e:
             raise ValueError(
-                f"The file at {str(yaml_file_path)} is not a valid YAML file."
+                f"The file at {yaml_file_path!s} is not a valid YAML file."
             ) from e
 
         # Initialize the pipeline space
-        pipeline_space = {}
+        pipeline_space: dict[str, Parameter] = {}
 
         # Iterate over the items in the YAML configuration
         for name, details in config.items():
@@ -157,16 +177,12 @@ def pipeline_space_from_yaml(
                 # Categorical parameter
                 pipeline_space[name] = CategoricalParameter(
                     choices=details["choices"],
-                    is_fidelity=details.get("is_fidelity", False),
                     default=details.get("default", None),
                     default_confidence=details.get("default_confidence", "low"),
                 )
             elif param_type in ("const", "constant"):
                 # Constant parameter
-                pipeline_space[name] = ConstantParameter(
-                    value=details["value"],
-                    is_fidelity=details.get("is_fidelity", False),
-                )
+                pipeline_space[name] = ConstantParameter(value=details["value"])
             else:
                 # Handle unknown parameter type
                 raise TypeError(
@@ -179,380 +195,659 @@ def pipeline_space_from_yaml(
                 )
     except (KeyError, TypeError, ValueError, FileNotFoundError) as e:
         raise SearchSpaceFromYamlFileError(e) from e
+
     return pipeline_space
 
 
 class SearchSpace(Mapping[str, Any]):
-    def __init__(self, **hyperparameters):
-        self.hyperparameters: dict[str, Parameter] = {}
+    """A container for hyperparameters that can be sampled, mutated, and crossed over.
 
-        self.fidelity = None
-        self.has_prior = False
-        for key, hyperparameter in hyperparameters.items():
-            self.hyperparameters[key] = hyperparameter
-            # Only integer / float parameters can be fidelities, so check these
-            if hyperparameter.is_fidelity:
-                if self.fidelity is not None:
+    Provides operations for operating on and generating new configurations from the
+    hyperparameters.
+
+    !!! note
+
+        The `SearchSpace` class is both the definition of the search space and also
+        a configuration at the same time.
+
+        When refering to the `SearchSpace` as a configuration, the documentation will
+        refer to it as a `configuration` or `config`. Otherwise, it will be referred to
+        as a `search space`.
+
+    !!! note "TODO"
+
+        This documentation is WIP. If you have any questions, please reach out so we can
+        know better what to document.
+    """
+
+    def __init__(self, **hyperparameters: Parameter):
+        """Initialize the SearchSpace with hyperparameters.
+
+        Args:
+            **hyperparameters: The hyperparameters that define the search space.
+        """
+        # Ensure a consistent ordering for uses throughout the lib
+        _hyperparameters = sorted(hyperparameters.items(), key=lambda x: x[0])
+        _fidelity_param: NumericalParameter | None = None
+        _has_prior: bool = False
+
+        for _, hp in _hyperparameters:
+            if hp.is_fidelity:
+                if _fidelity_param is not None:
                     raise ValueError(
                         "neps only supports one fidelity parameter in the pipeline space,"
                         " but multiple were given. (Hint: check you pipeline space for "
                         "multiple is_fidelity=True)"
                     )
-                if not isinstance(hyperparameter, FloatParameter):
+
+                if not isinstance(hp, NumericalParameter):
                     raise ValueError(
                         "neps only suport float and integer fidelity parameters"
                     )
-                self.fidelity = hyperparameter
 
-            # Check if defaults exists to construct prior from, except of
-            # ConstantParameter because default gets init always by the given value
-            if (
-                hasattr(hyperparameter, "default")
-                and hyperparameter.default is not None
-                and not isinstance(hyperparameter, ConstantParameter)
-            ):
-                self.has_prior = True
-            elif hasattr(hyperparameter, "has_prior") and hyperparameter.has_prior:
-                self.has_prior = True
+                _fidelity_param = hp
 
+            if isinstance(hp, ParameterWithPrior) and hp.has_prior:
+                _has_prior = True
+
+        self.hyperparameters: dict[str, Parameter] = dict(_hyperparameters)
+        self.fidelity: NumericalParameter | None = _fidelity_param
+        self.has_prior: bool = _has_prior
+
+        # TODO(eddiebergman): This should be a seperate thing most likely and not
+        # in a `SearchSpace`.
         # Variables for tabular bookkeeping
-        self.custom_grid_table = None
-        self.raw_tabular_space = None
-        self.has_tabular = None
+        self.custom_grid_table: pd.Series | pd.DataFrame | None = None
+        self.raw_tabular_space: SearchSpace | None = None
+        self.has_tabular: bool = False
 
     def set_custom_grid_space(
         self,
         grid_table: pd.Series | pd.DataFrame,
         raw_space: SearchSpace | CS.ConfigurationSpace,
-    ):
+    ) -> None:
         """Set a custom grid space for the search space.
 
         This function is used to set a custom grid space for the pipeline space.
-        NOTE: Only to be used if a custom set of hyperparameters from the search space
-        is to be sampled or used for acquisition functions.
-        WARNING: The type check and the table format requirement is loose and
-        can break certain components.
+
+        !!! warning
+
+            The type check and the table format requirement is loose and
+            can break certain components.
+
+        Note:
+            Only to be used if a custom set of hyperparameters from the search space
+            is to be sampled or used for acquisition functions.
         """
-        self.custom_grid_table: pd.DataFrame | pd.Series = grid_table
-        self.raw_tabular_space = (
-            SearchSpace(**raw_space)
-            if not isinstance(raw_space, SearchSpace)
-            else raw_space
-        )
-        if self.custom_grid_table is None or self.raw_tabular_space is None:
+        if grid_table is None or raw_space is None:
             raise ValueError(
                 "Both grid_table and raw_space must be set!\n"
                 "A table or list of fixed configs must be supported with a "
                 "continuous space representing the type and bounds of each "
                 "hyperparameter for accurate modeling."
             )
+
+        self.custom_grid_table = grid_table
+        self.raw_tabular_space = (
+            SearchSpace(**raw_space)
+            if not isinstance(raw_space, SearchSpace)
+            else raw_space
+        )
         self.has_tabular = True
 
     @property
-    def has_fidelity(self):
+    def has_fidelity(self) -> bool:
+        """Check if the search space has a fidelity parameter."""
         return self.fidelity is not None
 
-    def compute_prior(self, log: bool = False, ignore_fidelity=False):
+    def compute_prior(self, *, log: bool = False, ignore_fidelity: bool = False) -> float:
+        """Compute the prior probability of the search space.
+
+        This is better know as the `pdf` of the configuraiton in the search space, or a
+        relative measure of how likely this configuration is under the search space.
+
+        Args:
+            log: Whether to compute the log of the prior.
+            ignore_fidelity: Whether to ignore the fidelity parameter when
+                computing the prior.
+
+
+        Returns:
+            The likelihood of the configuration in the search space.
+        """
         density_value = 0.0 if log else 1.0
-        for hyperparameter in self.hyperparameters.values():
+        op = operator.add if log else operator.mul
+
+        prior_hps = (
+            hp
+            for hp in self.hyperparameters.values()
+            if isinstance(hp, ParameterWithPrior) and hp.has_prior
+        )
+
+        for hyperparameter in prior_hps:
             if ignore_fidelity and hyperparameter.is_fidelity:
                 continue
-            if hasattr(hyperparameter, "has_prior") and hyperparameter.has_prior:
-                if log:
-                    density_value += hyperparameter.compute_prior(log=True)
-                else:
-                    density_value *= hyperparameter.compute_prior(log=False)
+
+            hp_prior = hyperparameter.compute_prior(log=log)
+            density_value = op(density_value, hp_prior)
+
         return density_value
 
     def sample(
-        self, user_priors: bool = False, patience: int = 1, ignore_fidelity=True
+        self,
+        *,
+        user_priors: bool = False,
+        patience: int = 1,
+        ignore_fidelity: bool = True,
     ) -> SearchSpace:
-        sample = self.copy()
-        for hp_name, hyperparameter in sample.hyperparameters.items():
-            if hyperparameter.is_fidelity and ignore_fidelity:
+        """Sample a configuration from the search space.
+
+        Args:
+            user_priors: Whether to use user priors when sampling.
+            patience: The number of times to try to sample a valid value for a
+                hyperparameter.
+            ignore_fidelity: Whether to ignore the fidelity parameter when sampling.
+
+        Returns:
+            A sampled configuration from the search space.
+        """
+        sampled_hps: dict[str, Parameter] = {}
+
+        for name, hp in self.hyperparameters.items():
+            if hp.is_fidelity and ignore_fidelity:
+                sampled_hps[name] = hp.clone()
                 continue
+
             for _ in range(patience):
                 try:
-                    hyperparameter.sample(user_priors=user_priors)
-                    break
+                    if user_priors and isinstance(hp, ParameterWithPrior):
+                        sampled_hps[name] = hp.sample(user_priors=user_priors)
+                    else:
+                        sampled_hps[name] = hp.sample()
+
                 except ValueError:
                     pass
-            else:
-                raise ValueError(
-                    f"Could not sample valid config for {hp_name} in {patience} tries!"
-                )
+            raise ValueError(
+                f"Could not sample valid config for {name} in {patience} tries!"
+            )
 
-        if sample.has_tabular:
-            # each configuration does not need to carry the tabular data
-            sample.has_tabular = False
-            sample.custom_grid_table = None
-            sample.raw_tabular_space = None
-
-        return sample
+        return SearchSpace(**sampled_hps)
 
     def mutate(
         self,
-        parent=None,
+        *,
+        parent: SearchSpace | None = None,
         mutation_rate: float = 1.0,
-        mutation_strategy="smbo",
-        patience=50,
-        **kwargs,
-    ):
+        mutation_strategy: Literal["smbo"] = "smbo",
+        patience: int = 50,
+        **kwargs: Any,
+    ) -> SearchSpace:
+        """Mutate the search space.
+
+        Args:
+            parent: The parent configuration to mutate from.
+            mutation_rate: The rate at which to mutate the search space.
+            mutation_strategy: The strategy to use for mutation.
+            patience: The number of times to try to mutate a valid value for a
+                hyperparameter.
+            **kwargs: Additional keyword arguments to pass to the mutation strategy.
+
+        Returns:
+            The mutated search space.
+        """
         if mutation_strategy == "smbo":
             args = {
                 "parent": parent,
                 "mutation_rate": mutation_rate,
                 "mutation_strategy": "local_search",  # fixing property for SMBO mutation
-                "patience": patience,
             }
             kwargs.update(args)
-            new_config = self._smbo_mutation(**kwargs)
+            new_config = self._smbo_mutation(patience=patience, **kwargs)
         else:
             raise NotImplementedError("No such mutation strategy!")
 
-        child = SearchSpace(**new_config)
+        return SearchSpace(**new_config)
 
-        return child
-
-    def _smbo_mutation(self, patience=50, **kwargs):
-        new_config = deepcopy(self.hyperparameters)
-        config_hp_names = list(new_config)
+    # TODO(eddiebergman): This function seems very weak, i.e. it's only mutating
+    # one hyperparamter and copying the rest, very expensive for little gain.
+    def _smbo_mutation(self, *, patience: int = 50, **kwargs: Any) -> Self:
+        non_fidelity_mutatable_params = {
+            hp_name: hp
+            for hp_name, hp in self.hyperparameters.items()
+            if not hp.is_fidelity and isinstance(hp, MutatableParameter)
+        }
 
         for _ in range(patience):
-            idx = random.randint(0, len(new_config) - 1)
-            hp_name = config_hp_names[idx]
-            hp = new_config[hp_name]
-            if isinstance(hp, NumericalParameter) and hp.is_fidelity:
-                continue
+            chosen_hp_name = np.random.choice(list(non_fidelity_mutatable_params))
+            hp = non_fidelity_mutatable_params[chosen_hp_name]
+
             try:
-                new_config[hp_name] = hp.mutate(**kwargs)
-                break
-            except Exception as e:
-                self.logger.warning(f"{hp_name} FAILED! Error: {e}")
+                mutated_param = hp.mutate(**kwargs)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"{chosen_hp_name} failed to mutate! Error: {e}")
                 continue
-        return new_config
+
+            new_params = {
+                hp_name: hp.clone() if hp_name != chosen_hp_name else mutated_param
+                for hp_name, hp in self.hyperparameters.items()
+            }
+            return self.__class__(**new_params)
+
+        # TODO(eddiebergman): Should probably throw here... but this is what the previous
+        # behaviour did...
+        return self.__class__(
+            **{hp_name: hp.clone() for hp_name, hp in self.hyperparameters.items()}
+        )
 
     def crossover(
         self,
-        config2,
+        config2: SearchSpace,
         crossover_probability_per_hyperparameter: float = 1.0,
         patience: int = 50,
         crossover_strategy: str = "simple",
-    ):
+    ) -> tuple[SearchSpace, SearchSpace]:
+        """Crossover this configuration with another.
+
+        Args:
+            config2: The other search space to crossover with.
+            crossover_probability_per_hyperparameter: The probability of crossing over
+                each hyperparameter.
+            patience: The number of times to try to crossover a valid value for a
+                hyperparameter.
+            crossover_strategy: The strategy to use for crossover.
+
+        Returns:
+            A tuple of the two new configurations.
+        """
         if crossover_strategy == "simple":
             new_config1, new_config2 = self._simple_crossover(
-                config2, crossover_probability_per_hyperparameter, patience
+                config2=config2,
+                crossover_probability_per_hyperparameter=crossover_probability_per_hyperparameter,
+                patience=patience,
             )
         else:
             raise NotImplementedError("No such crossover strategy!")
 
         if len(self.hyperparameters.keys()) != len(new_config1):
             raise Exception("Cannot crossover")
-        child1 = SearchSpace(**dict(zip(self.hyperparameters.keys(), new_config1)))
-        child2 = SearchSpace(**dict(zip(self.hyperparameters.keys(), new_config2)))
-        return child1, child2
+
+        return SearchSpace(**new_config1), SearchSpace(**new_config2)
 
     def _simple_crossover(
         self,
-        config2,
+        config2: SearchSpace,
         crossover_probability_per_hyperparameter: float = 1.0,
         patience: int = 50,
-    ):
-        new_config1 = []
-        new_config2 = []
+    ) -> tuple[dict[str, Parameter], dict[str, Parameter]]:
+        new_config1: dict[str, Parameter] = {}
+        new_config2: dict[str, Parameter] = {}
+
         for key, hyperparameter in self.hyperparameters.items():
+            other_hp = config2.hyperparameters[key]
             if (
-                hasattr(hyperparameter, "crossover")
-                and np.random.random() < crossover_probability_per_hyperparameter
+                isinstance(hyperparameter, MutatableParameter)
                 and not hyperparameter.is_fidelity
+                and np.random.random() < crossover_probability_per_hyperparameter
             ):
-                while patience > 0:
+                for _ in range(patience):
                     try:
-                        child1, child2 = hyperparameter.crossover(
-                            config2.hyperparameters[key]
-                        )
-                        new_config1.append(child1)
-                        new_config2.append(child2)
-                        break
-                    except NotImplementedError:
-                        new_config1.append(hyperparameter)
-                        new_config2.append(config2.hyperparameters[key])
-                        break
-                    except Exception:
-                        patience -= 1
+                        child1, child2 = hyperparameter.crossover(other_hp)  # type: ignore
+                        new_config1[key] = child1
+                        new_config2[key] = child2
+                    except Exception:  # noqa: S112, BLE001
                         continue
+                    else:
+                        break
             else:
-                new_config1.append(hyperparameter)
-                new_config2.append(config2.hyperparameters[key])
+                new_config1[key] = hyperparameter.clone()
+                new_config2[key] = other_hp.clone()
 
         return new_config1, new_config2
 
-    def get_normalized_hp_categories(self, ignore_fidelity=False):
-        hps = {
+    def get_normalized_hp_categories(
+        self,
+        *,
+        ignore_fidelity: bool = False,
+    ) -> dict[Literal["continuous", "categorical", "graphs"], list[Any]]:
+        """Get the normalized values for each hyperparameter in the configuraiton.
+
+        Args:
+            ignore_fidelity: Whether to ignore the fidelity parameter when getting the
+                normalized values.
+
+        Returns:
+            A dictionary of the normalized values for each hyperparameter,
+            separated by type.
+        """
+        hps: dict[Literal["continuous", "categorical", "graphs"], list[Any]] = {
             "continuous": [],
             "categorical": [],
             "graphs": [],
         }
         for hp in self.values():
-            hp_value = hp.normalized().value
             if ignore_fidelity and hp.is_fidelity:
                 continue
+
             if isinstance(hp, ConstantParameter):
                 continue
-            elif isinstance(hp, CategoricalParameter):
+
+            # TODO(eddiebergman): Not sure this covers all graph parameters but a search
+            # for `def value` that have a property decorator is all that could have
+            # worked previously for graphs
+            if isinstance(hp, GraphParameter):
+                hps["graphs"].append(hp.value)
+                continue
+
+            if isinstance(hp, CategoricalParameter):
+                assert hp.value is not None
+                hp_value = hp.value_to_normalized(hp.value)
                 hps["categorical"].append(hp_value)
-            elif isinstance(hp, NumericalParameter):
+
+            # TODO(eddiebergman): Technically integer is not continuous
+            if isinstance(hp, NumericalParameter):
+                assert hp.value is not None
+                hp_value = hp.value_to_normalized(hp.value)
                 hps["continuous"].append(hp_value)
-            else:
-                hps["graphs"].append(hp_value)
+
+            raise NotImplementedError(f"Unknown Parameter type: {type(hp)}\n{hp}")
+
         return hps
 
-    def hp_values(self):
+    def hp_values(self) -> dict[str, Any]:
+        """Get the values for each hyperparameter in this configuration."""
         return {
-            hp_name: hp if isinstance(hp, Graph) else hp.value
+            hp_name: hp if isinstance(hp, GraphParameter) else hp.value
             for hp_name, hp in self.hyperparameters.items()
         }
 
-    def add_constant_hyperparameter(self, name=None, value=None):
-        if value is not None:
-            hp = ConstantParameter(value=value)
-        else:
-            raise NotImplementedError("Adding hps is supported only by value")
-        self.add_hyperparameter(name, hp)
+    def add_hyperparameter(self, name: str, hp: Parameter) -> None:
+        """Add a hyperparameter to the search space.
 
-    def add_hyperparameter(self, name=None, hp=None):
-        if name is None:
-            id_new_hp = len(self.hyperparameters)
-            while str(id_new_hp) in self.hyperparameters:
-                id_new_hp += 1
-        else:
-            id_new_hp = name
-        self.hyperparameters[str(id_new_hp)] = hp
+        Args:
+            name: The name of the hyperparameter.
+            hp: The hyperparameter to add.
+        """
+        self.hyperparameters[str(name)] = hp
+        self.hyperparameters = dict(
+            sorted(self.hyperparameters.items(), key=lambda x: x[0])
+        )
 
-    def get_vectorial_dim(self):
-        if not has_instance(self.values(), NumericalParameter):
+    def get_vectorial_dim(self) -> dict[Literal["continuous", "categorical"], int] | None:
+        """Get the vectorial dimension of the search space.
+
+        The count of [`NumericalParameter`][neps.search_spaces.NumericalParameter]
+        are put under the key `#!python "continuous"` and the count of
+        [`CategoricalParameter`][neps.search_spaces.CategoricalParameter] are put under
+        the key `#!python "categorical"` in the return dict.
+
+        If there are no numerical or categorical hyperparameters **or constant**
+        parameters, then `None` is returned.
+
+        Returns:
+            The vectorial dimension
+        """
+        # TODO(eddiebergman): Right now this ignores graph parameters,
+        # what should we do about this...
+        if any(isinstance(hp, GraphParameter) for hp in self.values()):
+            raise ValueError("Trying to get vectorial dimension for graphs!")
+
+        if not any(
+            isinstance(hp, (NumericalParameter, CategoricalParameter, ConstantParameter))
+            for hp in self.values()
+        ):
             return None
-        features = {"continuous": 0, "categorical": 0}
+
+        features: dict[Literal["continuous", "categorical"], int] = {
+            "continuous": 0,
+            "categorical": 0,
+        }
         for hp in self.values():
             if isinstance(hp, ConstantParameter):
                 continue
-            elif isinstance(hp, CategoricalParameter):
+
+            if isinstance(hp, CategoricalParameter):
                 features["categorical"] += 1
             elif isinstance(hp, NumericalParameter):
                 features["continuous"] += 1
+
         return features
 
-    def set_to_max_fidelity(self):
-        self.fidelity.value = self.fidelity.upper
+    def set_to_max_fidelity(self) -> None:
+        """Set the configuration to the maximum fidelity."""
+        if self.fidelity is None:
+            raise ValueError("No fidelity parameter in the search space!")
 
-    def get_search_space_grid(self, grid_step_size: int = 10):
+        self.fidelity.set_value(self.fidelity.upper)
+
+    def get_search_space_grid(
+        self,
+        *,
+        size_per_numerical_hp: int = 10,
+        include_endpoints: bool = True,
+    ) -> list[SearchSpace]:
+        """Get a grid of configurations from the search space.
+
+        For [`NumericalParameter`][neps.search_spaces.NumericalParameter] hyperparameters,
+        the parameter `size_per_numerical_hp=` is used to determine a grid. If there are
+        any duplicates, e.g. for an
+        [`IntegerParameter`][neps.search_spaces.IntegerParameter], then we will
+        remove duplicates.
+
+        For [`CategoricalParameter`][neps.search_spaces.CategoricalParameter]
+        hyperparameters, we include all the choices in the grid.
+
+        For [`ConstantParameter`][neps.search_spaces.ConstantParameter] hyperparameters,
+        we include the constant value in the grid.
+
+        !!! note "TODO"
+
+            Does not support graph parameters currently.
+
+        Args:
+            size_per_numerical_hp: The size of the grid for each numerical hyperparameter.
+            include_endpoints: Whether to include the endpoints of the grid.
+
+        Returns:
+            A list of configurations from the search space.
+        """
         param_ranges = []
         for hp in self.hyperparameters.values():
-            if isinstance(hp, Graph):
+            # NOTE(eddiebergman): This is a temporary fix to avoid graphs
+            # If this is resolved, please update the docstring!
+            if isinstance(hp, GraphParameter):
                 raise ValueError("Trying to create a grid for graphs!")
+
             if isinstance(hp, CategoricalParameter):
                 param_ranges.append(hp.choices)
-            else:
-                if hp.log:
-                    grid = np.exp(
-                        np.linspace(np.log(hp.lower), np.log(hp.upper), grid_step_size)
-                    )
-                else:
-                    grid = np.linspace(hp.lower, hp.upper, grid_step_size)
-                grid = np.clip(grid, hp.lower, hp.upper).astype(np.float32)
-                grid = grid.astype(int) if isinstance(hp, IntegerParameter) else grid
-                grid = np.unique(grid).tolist()
+                continue
+
+            if isinstance(hp, ConstantParameter):
+                param_ranges.append([hp.value])
+                continue
+
+            if isinstance(hp, NumericalParameter):
+                grid = hp.grid(
+                    size=size_per_numerical_hp,
+                    include_endpoint=include_endpoints,
+                )
+                _grid = np.clip(grid, hp.lower, hp.upper).astype(np.float64)
+                _grid = (
+                    _grid.astype(np.int64) if isinstance(hp, IntegerParameter) else _grid
+                )
+                _grid = np.unique(grid).tolist()
                 param_ranges.append(grid)
+                continue
+
+            raise NotImplementedError(f"Unknown Parameter type: {type(hp)}\n{hp}")
+
         full_grid = product(*param_ranges)
 
-        configs = []
-        for _config_dict in full_grid:
-            _config = self.copy()
-            for key, value in dict(
-                zip(self.hyperparameters.keys(), _config_dict)
-            ).items():
-                _config.add_constant_hyperparameter(name=key, value=value)
-            configs.append(_config)
-        return configs
+        return [
+            SearchSpace(
+                **{
+                    name: ConstantParameter(value=value)  # type: ignore
+                    for name, value in zip(self.hyperparameters.keys(), config_values)
+                }
+            )
+            for config_values in full_grid
+        ]
 
-    def serialize(self):
+    def serialize(self) -> dict[str, Hashable]:
+        """Serialize the configuration to a dictionary that can be written to disk."""
         return {key: hp.serialize() for key, hp in self.hyperparameters.items()}
 
-    def load_from(self, config: Mapping[str, Any]):
-        for name in config.keys():
-            self.hyperparameters[name].load_from(config[name])
+    def load_from(self, config: Mapping[str, Any]) -> None:
+        """Load a configuration from a dictionary, setting all the values."""
+        for name, val in config.items():
+            self.hyperparameters[name].load_from(val)
 
-    def copy(self):
-        return deepcopy(self)
+    def clone(self, *, _with_tabular: bool = False) -> SearchSpace:
+        """Create a copy of the search space."""
+        if _with_tabular:
+            return deepcopy(self)
+
+        # TODO(eddiebergman): While tabular is part of the search space, whenever we copy
+        # this, we make sure to remove the table first and then re-assign.
+        has_tabular = self.has_tabular
+        custom_grid_table = self.custom_grid_table
+        raw_tabular_space = self.raw_tabular_space
+
+        self.has_tabular = False
+        self.custom_grid_table = None
+        self.raw_tabular_space = None
+
+        _copy = deepcopy(self)
+
+        self.has_tabular = has_tabular
+        self.custom_grid_table = custom_grid_table
+        self.raw_tabular_space = raw_tabular_space
+
+        return _copy
 
     def sample_default_configuration(
-        self, patience: int = 1, ignore_fidelity=True, ignore_missing_defaults=False
-    ):
+        self,
+        *,
+        patience: int = 1,
+        ignore_fidelity: bool = True,
+        ignore_missing_defaults: bool = False,
+    ) -> SearchSpace:
+        """Sample the default configuration from the search space.
+
+        By default, if there is no default set for a hyperparameter, an error will be
+        raised. If `ignore_missing_defaults=True`, then a sampled value will be used
+        instead.
+
+        Args:
+            patience: The number of times to try to sample a valid value for a
+                hyperparameter.
+            ignore_fidelity: Whether to ignore the fidelity parameter when sampling.
+            ignore_missing_defaults: Whether to ignore missing defaults when setting
+                the default configuration.
+
+        Returns:
+            The default configuration.
+        """
+        # Sample a random config and then set the defaults if there are any
         config = self.sample(patience=patience, ignore_fidelity=ignore_fidelity)
         for hp_name, hp in self.hyperparameters.items():
-            if hp.is_fidelity or isinstance(hp, ConstantParameter):
+            if hp.is_fidelity and ignore_fidelity:
                 continue
-            elif hasattr(hp, "default") and hp.default is not None:
-                config[hp_name].value = hp.default
-            else:
+
+            if hp.default is None:
                 if not ignore_missing_defaults:
                     raise ValueError(f"No defaults specified for {hp} in the space.")
+
+                # Use the sampled value instead
+            else:
+                config[hp_name].set_value(hp.default)
+
         return config
 
-    def set_defaults_to_current_values(self):
+    def set_defaults_to_current_values(self) -> None:
+        """Update the configuration/search space to use the current values as defaults."""
         for hp in self.hyperparameters.values():
-            if hasattr(hp, "default"):
-                hp.default = hp.value
+            if isinstance(hp, NumericalParameter):
+                hp.set_default(hp.value)
 
-    def set_hyperparameters_from_dict(
+    def set_hyperparameters_from_dict(  # noqa: C901
         self,
-        hyperparameters,
-        defaults=True,
-        values=True,
-        confidence="low",
-        delete_previous_defaults=False,
-        delete_previous_values=False,
-        overwrite_constants=False,
-        # If new values / defaults are given, previous defaults / values are always
-        # overridden
-    ):
-        for hp_key, hp in self.hyperparameters.items():
-            # First check if there is a new value for the hp and that its value is valid
+        hyperparameters: Mapping[str, Any],
+        *,
+        defaults: bool = True,
+        values: bool = True,
+        # TODO(eddiebergman): The existence of this makes me think
+        # all hyperparameters that accept confidence should use the same keys
+        confidence: str = "low",
+        delete_previous_defaults: bool = False,
+        delete_previous_values: bool = False,
+        overwrite_constants: bool = False,
+    ) -> None:
+        """Set the hyperparameters from a dictionary of values.
+
+        !!! note "Constant Hyperparameters"
+
+            [`ConstantParameter`][neps.search_spaces.ConstantParameter] hyperparameters
+            have only a single possible value and hence only a single possible default.
+            If `overwrite_constants=` is `False`, then it will remain unchanged and
+            ignore the new value.
+
+            If `overwrite_constants=` is `True`, then the constant hyperparameter will
+            be updated, requiring both `defaults=True` and `values=True` to be set.
+
+            The arguments `delete_previous_defaults` and `delete_previous_values` are
+            ignored for [`ConstantParameter`][neps.search_spaces.ConstantParameter].
+
+        Args:
+            hyperparameters: The dictionary of hyperparameters to set with values.
+            defaults: Whether to set the defaults to these values.
+            values: Whether to set the value of the hyperparameters to these values.
+            confidence: The confidence score to use when setting the default.
+                Only applies if `defaults=True`.
+            delete_previous_defaults: Whether to delete the previous defaults.
+            delete_previous_values: Whether to delete the previous values.
+            overwrite_constants: Whether to overwrite constant hyperparameters.
+
+        Raises:
+            ValueError: If the value is invalid for the hyperparameter.
+        """
+        if values is False and defaults is False:
+            raise ValueError("At least one of `values` or `defaults` must be True.")
+
+        for hp_key, current_hp in self.hyperparameters.items():
+            new_hp_value = hyperparameters.get(hp_key, NotSet)
+            if isinstance(new_hp_value, _NotSet):
+                continue
+
+            # Handle constants specially as they have particular logic which
+            # is different from the other hyperparameters
+            if isinstance(current_hp, ConstantParameter):
+                if not overwrite_constants:
+                    continue
+
+                if not (defaults and values):
+                    raise ValueError(
+                        "Cannot have a constant parameter with a seperate default and"
+                        " and value. Please provide both `values=True` and"
+                        " `defaults=True` if passing `overwrite_constants=True`"
+                        f" with a new value for the constant '{hp_key}'."
+                    )
+
+                current_hp.set_constant_value(new_hp_value)
+                continue
+
             if delete_previous_defaults:
-                hp.default = None
-                hp.has_prior = False
+                current_hp.set_default(None)
+
             if delete_previous_values:
-                if not isinstance(hp, ConstantParameter) or overwrite_constants:
-                    hp.value = None
-            if hp_key not in hyperparameters:
-                continue
-            if self.hyperparameters[hp_key].is_fidelity:
-                hp.value = hyperparameters[hp_key]
-                continue
-            new_hp_value = hyperparameters[hp_key]
-            if isinstance(new_hp_value, Parameter):
-                new_hp_value = new_hp_value.value
-            if (
-                isinstance(hp, NumericalParameter)
-                and not hp.lower <= new_hp_value <= hp.upper
-            ):
-                continue
-            if isinstance(hp, CategoricalParameter) and new_hp_value not in hp.choices:
-                continue
-            if isinstance(hp, ConstantParameter) and not overwrite_constants:
-                continue
-            if defaults and hasattr(hp, "default"):
-                hp.default = new_hp_value
-                self.has_prior = True
-                hp.has_prior = True
-                if hasattr(hp, "set_default_confidence_score"):
-                    hp.set_default_confidence_score(confidence)
-                    print("set confidence to: ", confidence)
+                current_hp.set_value(None)
+
+            if defaults:
+                current_hp.set_default(new_hp_value)
+                if isinstance(current_hp, ParameterWithPrior):
+                    current_hp.set_default_confidence_score(confidence)
+
             if values:
-                hp.value = new_hp_value
-                if isinstance(hp, ConstantParameter):
-                    hp.lower = new_hp_value
-                    hp.upper = new_hp_value
+                current_hp.set_value(new_hp_value)
 
     def __getitem__(self, key: str) -> Parameter:
         return self.hyperparameters[key]
@@ -569,30 +864,42 @@ class SearchSpace(Mapping[str, Any]):
     def is_equal_value(
         self,
         other: SearchSpace,
+        *,
         include_fidelity: bool = True,
         on_decimal: int = 8,
     ) -> bool:
-        # This does NOT check that the entire SearchSpace is equal (and thus it is
-        # not a dunder method), but only checks the configuration
+        """Check if the configuration is equal to another configuration.
+
+        !!! warning
+
+            This does **NOT** check that the entire `SearchSpace` is equal (and thus it is
+            not a dunder method), but only checks the configuration values.
+
+        Args:
+            other: The other configuration to compare to.
+            include_fidelity: Whether to include the fidelity parameter in the comparison.
+            on_decimal: The decimal to round to when comparing float values.
+
+        Returns:
+            Whether the configuration values are equal.
+        """
         if self.hyperparameters.keys() != other.hyperparameters.keys():
             return False
 
-        equal_values = [True] * len(self.hyperparameters)
-        for hp_idx, hp in enumerate(self.hyperparameters.keys()):
-            if self.hyperparameters[hp].is_fidelity and (not include_fidelity):
+        for hp_key, this_hp in self.hyperparameters.items():
+            if this_hp.is_fidelity and (not include_fidelity):
                 continue
-            else:
-                equal_values[hp_idx] = (
-                    self.hyperparameters[hp] == other.hyperparameters[hp]
-                )
 
-            if isinstance(self.hyperparameters[hp].value, float):
-                equal_values[hp_idx] = (
-                    np.round(
-                        self.hyperparameters[hp].normalized().value
-                        - other.hyperparameters[hp].normalized().value,
-                        on_decimal,
-                    )
-                    == 0
-                )
-        return all(equal_values)
+            other_hp = other.hyperparameters[hp_key]
+            if not isinstance(other_hp, type(this_hp)):
+                return False
+
+            if isinstance(this_hp.value, float):
+                this_norm = this_hp.value_to_normalized(this_hp.value)
+                other_norm = other_hp.value_to_normalized(other_hp.value)  # type: ignore
+                if np.round(this_norm - other_norm, on_decimal) != 0:
+                    return False
+            elif this_hp.value != other_hp.value:
+                return False
+
+        return True

--- a/neps/search_spaces/search_space.py
+++ b/neps/search_spaces/search_space.py
@@ -228,9 +228,10 @@ class SearchSpace(Mapping[str, Any]):
         # Ensure a consistent ordering for uses throughout the lib
         _hyperparameters = sorted(hyperparameters.items(), key=lambda x: x[0])
         _fidelity_param: NumericalParameter | None = None
+        _fidelity_name: str | None = None
         _has_prior: bool = False
 
-        for _, hp in _hyperparameters:
+        for name, hp in _hyperparameters:
             if hp.is_fidelity:
                 if _fidelity_param is not None:
                     raise ValueError(
@@ -245,12 +246,14 @@ class SearchSpace(Mapping[str, Any]):
                     )
 
                 _fidelity_param = hp
+                _fidelity_name = name
 
             if isinstance(hp, ParameterWithPrior) and hp.has_prior:
                 _has_prior = True
 
         self.hyperparameters: dict[str, Parameter] = dict(_hyperparameters)
         self.fidelity: NumericalParameter | None = _fidelity_param
+        self.fidelity_name: str | None = _fidelity_name
         self.has_prior: bool = _has_prior
 
         # TODO(eddiebergman): This should be a seperate thing most likely and not

--- a/neps/utils/_rng.py
+++ b/neps/utils/_rng.py
@@ -41,7 +41,7 @@ class SeedState:
         Takes a snapshot, including cloning or copying any arrays, tensors, etc.
         """
         # https://numpy.org/doc/stable/reference/random/generated/numpy.random.get_state.html
-        np_keys = np.random.get_state(legacy=True)  # noqa: NPY002
+        np_keys = np.random.get_state(legacy=True)
         assert np_keys[0] == "MT19937"  # type: ignore
         np_keys = (np_keys[0], np_keys[1].copy(), *np_keys[2:])  # type: ignore
 
@@ -60,7 +60,7 @@ class SeedState:
 
     def set_as_global_state(self) -> None:
         """Set the global rng to the given state."""
-        np.random.set_state(self.np_rng)  # noqa: NPY002
+        np.random.set_state(self.np_rng)
         random.setstate(self.py_rng)
         torch.random.set_rng_state(self.torch_rng)
         if self.torch_cuda_rng and torch.cuda.is_available():

--- a/neps/utils/data_loading.py
+++ b/neps/utils/data_loading.py
@@ -7,7 +7,7 @@ import os
 import re
 from itertools import chain
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, Mapping, TypedDict
 
 import numpy as np
 import yaml
@@ -45,7 +45,7 @@ def _get_loss(
 
 
 def _get_cost(
-    result: str | dict | float,
+    result: ERROR | ResultDict | float,
     cost_value_on_error: float | None = None,
     *,
     ignore_errors: bool = False,
@@ -65,7 +65,7 @@ def _get_cost(
 
         return cost_value_on_error
 
-    if isinstance(result, dict):
+    if isinstance(result, Mapping):
         return float(result["cost"])
 
     return float(result)

--- a/neps/utils/types.py
+++ b/neps/utils/types.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Mapping, Union
 from typing_extensions import TypeAlias
 
+import numpy as np
+import torch
+
 if TYPE_CHECKING:
     from neps.search_spaces.search_space import SearchSpace
 
@@ -15,10 +18,26 @@ if TYPE_CHECKING:
 # point to prevent having to isinstance and str match
 ERROR: TypeAlias = Literal["error"]
 
+Number: TypeAlias = Union[int, float, np.number]
+Array: TypeAlias = Union[np.ndarray, torch.Tensor]
+
 ConfigID: TypeAlias = str
 RawConfig: TypeAlias = Mapping[str, Any]
 Metadata: TypeAlias = Dict[str, Any]
 ResultDict: TypeAlias = Mapping[str, Any]
+
+# NOTE(eddiebergman): Getting types for scipy distributions sucks
+# this is more backwards compatible and easier to work with
+TruncNorm: TypeAlias = Any
+
+
+class _NotSet:
+    def __repr__(self) -> str:
+        return "NotSet"
+
+
+NotSet = _NotSet()
+
 
 POST_EVAL_HOOK_SIGNATURE: TypeAlias = Callable[
     [
@@ -30,6 +49,9 @@ POST_EVAL_HOOK_SIGNATURE: TypeAlias = Callable[
     ],
     None,
 ]
+
+f64 = np.float64
+i64 = np.int64
 
 
 # TODO(eddiebergman): Ideally, use `Trial` objects which can carry a lot more

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,8 @@ src = ["neps"]
 # TODO(eddiebergman): Include more of these as we go on in migration
 exclude = [
   "neps/optimizers/**/*.py",
-  "neps/search_spaces/**/*.py",
+  "neps/search_spaces/architecture/**/*.py",
+  "neps/search_spaces/yaml_search_space_utils.py",
   "neps/utils/run_args_from_yaml.py",
   "neps/api.py",
   "tests",
@@ -206,7 +207,8 @@ ignore = [
   "PD011",   # Use .to_numpy() instead of .values  (triggers on report.values)
   "COM812",  # Require trailing commas, recommended to ignore due to ruff formatter
   "PLR2004", # No magic numbers inline
-  # These tend to be lighweight and confuse pyright
+  "N817",    # CamelCase import as (ignore for ConfigSpace)
+  "NPY002",  # Replace legacy `np.random.choice` call with `np.random.Generator`
 ]
 
 
@@ -298,7 +300,8 @@ check_untyped_defs = true
 module = [
   "neps.api",
   "neps.optimizers.*",
-  "neps.search_spaces.*",
+  "neps.search_spaces.architecture.*",
+  "neps.search_spaces.yaml_search_space_utils",
   "neps.utils.run_args_from_yaml",
 ]
 ignore_errors = true

--- a/tests/test_runtime/test_locking.py
+++ b/tests/test_runtime/test_locking.py
@@ -37,8 +37,8 @@ def test_filelock() -> None:
     #   perform some predefined operation which is known to this test. If the example
     #   changes in some unexpected way, it may break this test
     results_dir = Path("results") / "hyperparameters_example" / "results"
+    assert not results_dir.exists(), "Please delete this directory before running the test"
     try:
-        assert not results_dir.exists()
         # Wait for them
         p_list = launch_example_processes(n_workers=2)
         for p in p_list:
@@ -49,13 +49,17 @@ def test_filelock() -> None:
             pending_re = r"#Pending configs with worker:\s+(\d+)"
             eval_re = r"#Evaluated configs:\s+(\d+)"
 
-            evaluated = first_true(re.match(eval_re, l) for l in lines)  # noqa
+            evaluated = first_true((re.match(eval_re, l) for l in lines), default=0)  # noqa
             pending = first_true((re.match(pending_re, l) for l in lines), default=0)  # noqa
 
             assert evaluated is not None
             assert pending is not None
 
-            evaluated_configs = int(evaluated.groups()[0])
+            if evaluated == 0:
+                evaluated_configs = 0
+            else:
+                evaluated_configs = int(evaluated.groups()[0])  # type: ignore
+
             if pending == 0:
                 pending_configs = 0
             else:

--- a/tests/test_yaml_search_space/test_search_space.py
+++ b/tests/test_yaml_search_space/test_search_space.py
@@ -23,13 +23,13 @@ def test_correct_yaml_files():
         assert int1.__eq__(pipeline_space["param_int1"]) is True
         int2 = IntegerParameter(100, 30000, log=True, is_fidelity=False)
         assert int2.__eq__(pipeline_space["param_int2"]) is True
-        float2 = FloatParameter(3.3e-5, 0.15, log=False,is_fidelity= False)
+        float2 = FloatParameter(3.3e-5, 0.15, log=False)
         assert float2.__eq__(pipeline_space["param_float2"]) is True
-        cat1 = CategoricalParameter([2, "sgd", 10e-3],is_fidelity= False)
+        cat1 = CategoricalParameter([2, "sgd", 10e-3])
         assert cat1.__eq__(pipeline_space["param_cat"]) is True
-        const1 = ConstantParameter(0.5,is_fidelity= False)
+        const1 = ConstantParameter(0.5)
         assert const1.__eq__(pipeline_space["param_const1"]) is True
-        const2 = ConstantParameter(1e3,is_fidelity= True)
+        const2 = ConstantParameter(1e3)
         assert const2.__eq__(pipeline_space["param_const2"]) is True
 
     test_correct_yaml_file(BASE_PATH + "correct_config.yaml")
@@ -47,9 +47,9 @@ def test_correct_including_priors_yaml_file():
     assert float1.__eq__(pipeline_space["learning_rate"]) is True
     int1 = IntegerParameter(3, 30, log=False, is_fidelity=True, default=10)
     assert int1.__eq__(pipeline_space["num_epochs"]) is True
-    cat1 = CategoricalParameter(["adam", 90e-3, "rmsprop"], is_fidelity=False, default=90e-3, default_confidence="medium")
+    cat1 = CategoricalParameter(["adam", 90e-3, "rmsprop"], default=90e-3, default_confidence="medium")
     assert cat1.__eq__(pipeline_space["optimizer"]) is True
-    const1 = ConstantParameter(1e3, is_fidelity=True)
+    const1 = ConstantParameter(1e3)
     assert const1.__eq__(pipeline_space["dropout_rate"]) is True
 
 
@@ -135,16 +135,6 @@ def test_float_is_fidelity_not_boolean():
         )
     assert excinfo.value.exception_type == "TypeError"
 
-
-@pytest.mark.neps_api
-def test_cat_is_fidelity_not_boolean():
-    """Test if an exception is raised when for CategoricalParameter the 'is_fidelity'
-    attribute is not boolean."""
-    with pytest.raises(SearchSpaceFromYamlFileError) as excinfo:
-        pipeline_space_from_yaml(
-            BASE_PATH + "not_boolean_type_is_fidelity_cat_config.yaml"
-        )
-    assert excinfo.value.exception_type == "TypeError"
 
 
 @pytest.mark.neps_api


### PR DESCRIPTION
This PR attempts to clean up and document the SearchSpace setup as well as a few other minor optimizations. This is to make progress towards an 1) ask-and-tell interface for benchmarking algorithmic changes/decisions easily and fast, 2) importantly *fast*, the latest set of changes tried to be self contained to their modules but have sped up things from `6.2seconds` after improvements from for the basic example to `1.2seconds` and now to `0.7seconds` (excluding import time).

All of this is not super important when considering the time to train models but this is unfortunately the difference of being able to quickly ablate and benchmark changes required for both CI and developing new research methods.

---

The most important contributions of this PR is to avoid the use of `deepcopy` on `SearchSpace` objects and instead resort to using `clone()` where possible. This simply just calls the constructor with the arugments and sets the value if any.
1. Object construction tends to be a little faster than deepcopying
2. If migrating away from the joint use of the `SearchSpace` as both a space definition and config, then now it's detectable as to where these clones occur.
 
Here the changes this PR makes to a simple sampling in the script below which does a simple generate 1000 configs, 100 times.
```
Mean time: 0.1886 seconds -> 0.1258
Std time: 0.0378 seconds -> 0.0377
Min time: 0.1547 seconds -> 0.113
Max time: 0.267 seconds -> 0.2273
```

I imagine switch to a non-copy and dedicated configuration object could drop this down to `0.05`. For reference, some recent optimization work for ConfigSpace which removed cython based things has it at around `0.3` seconds.

This is ignoring the fact most optimizers/acq. functions then have to extract all the information and put them in some array structure which is not show in the figure above, and then de-allocate all the clones.
 
---

Along with that, there's now documentation and typing so it's been re-enabled in ruff and mypy.

---

I don't really know what's going on with the graphs under the hood but after some debugging and investigations, these don't share a lot of similarities with a `Parameter` and it's more of a _overlap of behaviour_ then really belonging to the heirarchy.

Future PR's from this insight might consider making them seperate classes with no shared implementation such that consuming code can knowingly decide what to do on detection of a `GraphParameter`, e.g. you may not immediatly know you can't mutate some of them or that it can be vectorized to a number/set of numbers, which would be important to know for a PFN-surrogate for example.

---

```python
from __future__ import annotations

import time

import numpy as np

# ruff: noqa: T201
import neps
from neps.search_spaces.search_space import SearchSpace


def main():
    ss = SearchSpace(
        a=neps.IntegerParameter(0, 10),
        b=neps.IntegerParameter(1, 1000, log=True),
        c=neps.FloatParameter(0, 10, log=False),
        d=neps.FloatParameter(1, 1000, log=True),
        e=neps.CategoricalParameter(["a", "b", "c"]),
    )

    times = []
    for _ in range(100):
        start = time.time()
        _samples = [ss.sample() for _ in range(1000)]
        times.append(time.time() - start)

    print(f"Mean time: {sum(times) / len(times):.4f} seconds")
    print(f"Std time: {np.std(times):.4f} seconds")
    print(f"Min time: {min(times):.4f} seconds")
    print(f"Max time: {max(times):.4f} seconds")


if __name__ == "__main__":
    main()
```