### PR TITLE
fix(runtime): explicitly load previous results

### DIFF
--- a/neps/optimizers/base_optimizer.py
+++ b/neps/optimizers/base_optimizer.py
@@ -6,6 +6,7 @@ from typing import Any, Iterator, Mapping
 from typing_extensions import Self
 from contextlib import contextmanager
 from pathlib import Path
+from neps.optimizers.ask_and_tell import AskAndTellWrapper
 
 from neps.utils.types import ConfigResult, RawConfig, ERROR, ResultDict
 from neps.utils.files import serialize, deserialize
@@ -121,3 +122,6 @@ class BaseOptimizer:
     def is_out_of_budget(self) -> bool:
         """Check if the optimizer has used all of its budget, if any."""
         return self.budget is not None and self.used_budget >= self.budget
+
+    def to_ask_and_tell(self, working_dir: Path | str) -> AskAndTellWrapper:
+        return AskAndTellWrapper(working_dir=Path(working_dir), optimizer=self)

--- a/neps/optimizers/base_optimizer.py
+++ b/neps/optimizers/base_optimizer.py
@@ -6,7 +6,6 @@ from typing import Any, Iterator, Mapping
 from typing_extensions import Self
 from contextlib import contextmanager
 from pathlib import Path
-from neps.optimizers.ask_and_tell import AskAndTellWrapper
 
 from neps.utils.types import ConfigResult, RawConfig, ERROR, ResultDict
 from neps.utils.files import serialize, deserialize
@@ -122,6 +121,3 @@ class BaseOptimizer:
     def is_out_of_budget(self) -> bool:
         """Check if the optimizer has used all of its budget, if any."""
         return self.budget is not None and self.used_budget >= self.budget
-
-    def to_ask_and_tell(self, working_dir: Path | str) -> AskAndTellWrapper:
-        return AskAndTellWrapper(working_dir=Path(working_dir), optimizer=self)

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -170,7 +170,8 @@ class FloatParameter(NumericalParameter[float]):
             low, high = self.lower, self.upper
 
         normalized_value = normalized_value * (high - low) + low
-        return np.exp(normalized_value) if self.log else normalized_value
+        _value = np.exp(normalized_value) if self.log else normalized_value
+        return float(_value)
 
     @override
     def _get_non_unique_neighbors(

--- a/neps/utils/types.py
+++ b/neps/utils/types.py
@@ -91,7 +91,7 @@ class _ConfigResultForStats:
     @property
     def loss(self) -> float | ERROR:
         if isinstance(self.result, dict):
-            return self.result["loss"]
+            return float(self.result["loss"])
         return "error"
 
 


### PR DESCRIPTION
* closes #103
* closes #104

Test by rerunning the reproducible examples (Many thanks @danrgll!)

---

The issue was from my previous re-working runtime, where I forgot to ensure that if there was a trial (i.e. `config_1_1`) that relied on a previous trial (`config_1_0`), to ensure that it was loaded into that cache **before** `config_1_1` was loaded in. Main fix was just to sort accordingly and then process each one 1-by-1.

```python
        # NOTE: We sort all trials such that we process previous trials first, i.e.
        # if trial_3 has trial_2 as previous, we process trial_2 first, which
        # requires trial_1 to have been processed first.
        def _depth(trial: Trial.Disk) -> int:
            depth = 0
            previous = trial.previous_config_id
            while previous is not None:
                depth += 1
                previous_trial = _disk_lookup.get(previous)
                if previous_trial is None:
                    raise RuntimeError(
                        "Previous trial not found on disk when processing a trial."
                        " This should not happen as if a tria has a previous trial,"
                        " then it should be present and evaluated on disk.",
                    )
                previous = previous_trial.previous_config_id

            return depth

        # This allows is to traverse linearly and used cached values of previous
        # trial data loading, as done below.
        _disks.sort(key=_depth)

        for disk in _disks:
            # process the trial
```

---

PR also attempts to simplify things a bit and reduce some duplication, as fixing this issue would have introduced a lot of spaghetti.
