### PR TITLE
ux: Improve message on how to deal with an error from a worker

### DIFF
--- a/neps/exceptions.py
+++ b/neps/exceptions.py
@@ -45,3 +45,10 @@ class TrialNotFoundError(VersionedResourceDoesNotExistsError):
 
 class WorkerFailedToGetPendingTrialsError(NePSError):
     """Raised when a worker failed to get pending trials."""
+
+
+class WorkerRaiseError(NePSError):
+    """Raised from a worker when an error is raised.
+
+    Includes additional information on how to recover
+    """

--- a/tests/test_runtime/test_error_handling_strategies.py
+++ b/tests/test_runtime/test_error_handling_strategies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from neps.exceptions import WorkerRaiseError
 import pytest
 from dataclasses import dataclass
 from pandas.core.common import contextlib
@@ -59,7 +60,7 @@ def test_worker_raises_when_error_in_self(
         settings=settings,
         _pre_sample_hooks=None,
     )
-    with pytest.raises(ValueError, match="This is an error"):
+    with pytest.raises(WorkerRaiseError):
         worker.run()
 
     trials = neps_state.get_all_trials()

--- a/tests/test_runtime/test_error_handling_strategies.py
+++ b/tests/test_runtime/test_error_handling_strategies.py
@@ -108,7 +108,7 @@ def test_worker_raises_when_error_in_other_worker(neps_state: NePSState) -> None
     )
 
     # Worker1 should run 1 and error out
-    with contextlib.suppress(ValueError):
+    with contextlib.suppress(WorkerRaiseError):
         worker1.run()
 
     # Worker2 should not run and immeditaly error out, however
@@ -177,7 +177,7 @@ def test_worker_does_not_raise_when_error_in_other_worker(
 
     # Worker1 should run 1 and error out
     evaler.do_raise = True
-    with contextlib.suppress(ValueError):
+    with contextlib.suppress(WorkerRaiseError):
         worker1.run()
     assert worker1.worker_cumulative_eval_count == 1
 

--- a/tests/test_runtime/test_error_handling_strategies.py
+++ b/tests/test_runtime/test_error_handling_strategies.py
@@ -113,7 +113,7 @@ def test_worker_raises_when_error_in_other_worker(neps_state: NePSState) -> None
 
     # Worker2 should not run and immeditaly error out, however
     # it will have loaded in a serialized error
-    with pytest.raises(SerializedError):
+    with pytest.raises(WorkerRaiseError):
         worker2.run()
 
     trials = neps_state.get_all_trials()


### PR DESCRIPTION
* Closes #62 

When an error happens in a worker which does not ignore errors.

```python
Traceback (most recent call last):
  File "/home/skantify/code/neps/neps/state/_eval.py", line 125, in _eval_trial
    user_result = fn(**kwargs, **trial.config)
  File "/home/skantify/code/neps/neps_examples/basic_usage/hyperparameters.py", line 11, in run_pipeline
    raise ValueError("Something went wrong!")
ValueError: Something went wrong!

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/skantify/code/neps/neps_examples/basic_usage/hyperparameters.py", line 25, in <module>
    neps.run(
  File "/home/skantify/code/neps/neps/api.py", line 232, in run
    _launch_runtime(
  File "/home/skantify/code/neps/neps/runtime.py", line 556, in _launch_runtime
    worker.run()
  File "/home/skantify/code/neps/neps/runtime.py", line 378, in run
    should_stop = self._check_if_should_stop(
  File "/home/skantify/code/neps/neps/runtime.py", line 228, in _check_if_should_stop
    raise WorkerRaiseError(msg) from error_from_this_worker
neps.exceptions.WorkerRaiseError: Error occurred while evaluating a configuration with this worker and the worker is set to stop with OnErrorPossibilities.RAISE_ANY_ERROR.

If this was a bug in the evaluation code while you were developing your pipeline and you have set ignore_errors=True, please delete your results folder and fix the error before re-running.
If this is an issue specifically with the configuration, considering setting `ignore_errors=False` to allow the worker to continue evaluating other configurations, even if this one failed.
```

When you run another worker which is set not to ignore errors.

```python
neps.state.err_dump.SerializedError: An error occurred during the evaluation of a trial '1' which was evaluted by worker '183039-2024-08-05T16:50:06.087931+00:00'. The original error could not be deserialized but had the following information:
ValueError: Something went wrong!

Traceback (most recent call last):
  File "/home/skantify/code/neps/neps/state/_eval.py", line 125, in _eval_trial
    user_result = fn(**kwargs, **trial.config)
  File "/home/skantify/code/neps/neps_examples/basic_usage/hyperparameters.py", line 11, in run_pipeline
    raise ValueError("Something went wrong!")
ValueError: Something went wrong!


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/skantify/code/neps/neps_examples/basic_usage/hyperparameters.py", line 25, in <module>
    neps.run(
  File "/home/skantify/code/neps/neps/api.py", line 232, in run
    _launch_runtime(
  File "/home/skantify/code/neps/neps/runtime.py", line 556, in _launch_runtime
    worker.run()
  File "/home/skantify/code/neps/neps/runtime.py", line 378, in run
    should_stop = self._check_if_should_stop(
  File "/home/skantify/code/neps/neps/runtime.py", line 295, in _check_if_should_stop
    raise WorkerRaiseError(msg) from err
neps.exceptions.WorkerRaiseError: An error occurred in another worker and this worker is set to stop with OnErrorPossibilities.RAISE_ANY_ERROR.
If this was a bug in the evaluation code while you were developing your pipeline and you have set ignore_errors=True, please delete your results folder and fix the error before re-running.
If this is an issue specifically with the configuration, considering setting `ignore_errors=False` to allow the worker to continue evaluating other configurations, even if any worker fails.
```