### PR TITLE
refactor: rename `neps.FloatParameter` to `neps.Float`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ def run_pipeline(
 
 # 2. Define a search space of parameters; use the same parameter names as in run_pipeline
 pipeline_space = dict(
-    hyperparameter_a=neps.FloatParameter(
+    hyperparameter_a=neps.Float(
         lower=0.001, upper=0.1, log=True  # The search space is sampled in log space
     ),
     hyperparameter_b=neps.IntegerParameter(lower=1, upper=42),

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import logging
 
 # 1. Define a function that accepts hyperparameters and computes the validation error
 def run_pipeline(
-    hyperparameter_a: float, hyperparameter_b: int, architecture_parameter: str
+        hyperparameter_a: float, hyperparameter_b: int, architecture_parameter: str
 ) -> dict:
     # Create your model
     model = MyModel(architecture_parameter)
@@ -77,10 +77,9 @@ pipeline_space = dict(
     hyperparameter_a=neps.Float(
         lower=0.001, upper=0.1, log=True  # The search space is sampled in log space
     ),
-    hyperparameter_b=neps.IntegerParameter(lower=1, upper=42),
-    architecture_parameter=neps.CategoricalParameter(["option_a", "option_b"]),
+    hyperparameter_b=neps.Integer(lower=1, upper=42),
+    architecture_parameter=neps.Categorical(["option_a", "option_b"]),
 )
-
 
 # 3. Run the NePS optimization
 logging.basicConfig(level=logging.INFO)

--- a/docs/doc_yamls/architecture_search_space.py
+++ b/docs/doc_yamls/architecture_search_space.py
@@ -86,12 +86,12 @@ def set_recursive_attribute(op_name, predecessor_values):
 
 
 pipeline_space = dict(
-    architecture=neps.ArchitectureParameter(
+    architecture=neps.Architecture(
         set_recursive_attribute=set_recursive_attribute,
         structure=structure,
         primitives=primitives,
     ),
-    optimizer=neps.CategoricalParameter(choices=["sgd", "adam"]),
+    optimizer=neps.Categorical(choices=["sgd", "adam"]),
     learning_rate=neps.Float(lower=10e-7, upper=10e-3, log=True),
 )
 

--- a/docs/doc_yamls/architecture_search_space.py
+++ b/docs/doc_yamls/architecture_search_space.py
@@ -92,6 +92,6 @@ pipeline_space = dict(
         primitives=primitives,
     ),
     optimizer=neps.CategoricalParameter(choices=["sgd", "adam"]),
-    learning_rate=neps.FloatParameter(lower=10e-7, upper=10e-3, log=True),
+    learning_rate=neps.Float(lower=10e-7, upper=10e-3, log=True),
 )
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,10 +35,11 @@ In code, the usage pattern can look like this:
 import neps
 import logging
 
-def run_pipeline( # (1)!
-    hyperparameter_a: float,
-    hyperparameter_b: int,
-    architecture_parameter: str,
+
+def run_pipeline(  # (1)!
+        hyperparameter_a: float,
+        hyperparameter_b: int,
+        architecture_parameter: str,
 ) -> dict:
     # insert here your own model
     model = MyModel(architecture_parameter)
@@ -49,7 +50,7 @@ def run_pipeline( # (1)!
     )
 
     return {
-        "loss": validation_error, #! (2)
+        "loss": validation_error,  # ! (2)
         "info_dict": {
             "training_error": training_error
             # + Other metrics
@@ -58,9 +59,9 @@ def run_pipeline( # (1)!
 
 
 pipeline_space = {  # (3)!
-    "hyperparameter_b":neps.IntegerParameter(1, 42, is_fidelity=True), #! (4)
-    "hyperparameter_a":neps.Float(1e-3, 1e-1, log=True) #! (5)
-    "architecture_parameter": neps.CategoricalParameter(["option_a", "option_b", "option_c"]),
+    "hyperparameter_b": neps.Integer(1, 42, is_fidelity=True),  # ! (4)
+    "hyperparameter_a": neps.Float(1e-3, 1e-1, log=True)  # ! (5)
+    "architecture_parameter": neps.Categorical(["option_a", "option_b", "option_c"]),
 }
 
 if __name__ == "__main__":

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ def run_pipeline( # (1)!
 
 pipeline_space = {  # (3)!
     "hyperparameter_b":neps.IntegerParameter(1, 42, is_fidelity=True), #! (4)
-    "hyperparameter_a":neps.FloatParameter(1e-3, 1e-1, log=True) #! (5)
+    "hyperparameter_a":neps.Float(1e-3, 1e-1, log=True) #! (5)
     "architecture_parameter": neps.CategoricalParameter(["option_a", "option_b", "option_c"]),
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ import logging
 
 # 1. Define a function that accepts hyperparameters and computes the validation error
 def run_pipeline(
-    hyperparameter_a: float, hyperparameter_b: int, architecture_parameter: str
+        hyperparameter_a: float, hyperparameter_b: int, architecture_parameter: str
 ) -> dict:
     # Create your model
     model = MyModel(architecture_parameter)
@@ -83,10 +83,9 @@ pipeline_space = dict(
     hyperparameter_a=neps.Float(
         lower=0.001, upper=0.1, log=True  # The search space is sampled in log space
     ),
-    hyperparameter_b=neps.IntegerParameter(lower=1, upper=42),
-    architecture_parameter=neps.CategoricalParameter(["option_a", "option_b"]),
+    hyperparameter_b=neps.Integer(lower=1, upper=42),
+    architecture_parameter=neps.Categorical(["option_a", "option_b"]),
 )
-
 
 # 3. Run the NePS optimization
 logging.basicConfig(level=logging.INFO)

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ def run_pipeline(
 
 # 2. Define a search space of parameters; use the same parameter names as in run_pipeline
 pipeline_space = dict(
-    hyperparameter_a=neps.FloatParameter(
+    hyperparameter_a=neps.Float(
         lower=0.001, upper=0.1, log=True  # The search space is sampled in log space
     ),
     hyperparameter_b=neps.IntegerParameter(lower=1, upper=42),

--- a/docs/reference/pipeline_space.md
+++ b/docs/reference/pipeline_space.md
@@ -12,10 +12,10 @@ effectively incorporate various parameter types, ensuring that NePS can utilize 
 ## Parameters
 NePS currently features 4 primary hyperparameter types:
 
-* [`CategoricalParameter`][neps.search_spaces.hyperparameters.categorical.CategoricalParameter]
+* [`Categorical`][neps.search_spaces.hyperparameters.categorical.Categorical]
 * [`Float`][neps.search_spaces.hyperparameters.float.Float]
-* [`IntegerParameter`][neps.search_spaces.hyperparameters.integer.IntegerParameter]
-* [`ConstantParameter`][neps.search_spaces.hyperparameters.constant.ConstantParameter]
+* [`Integer`][neps.search_spaces.hyperparameters.integer.Integer]
+* [`Constant`][neps.search_spaces.hyperparameters.constant.Constant]
 
 Using these types, you can define the parameters that NePS will optimize during the search process.
 The most basic way to pass these parameters is through a Python dictionary, where each key-value
@@ -26,31 +26,31 @@ for optimizing a deep learning model:
 ```python
 pipeline_space = {
     "learning_rate": neps.Float(0.00001, 0.1, log=True),
-    "num_epochs": neps.IntegerParameter(3, 30, is_fidelity=True),
-    "optimizer": neps.CategoricalParameter(["adam", "sgd", "rmsprop"]),
-    "dropout_rate": neps.ConstantParameter(0.5),
+    "num_epochs": neps.Integer(3, 30, is_fidelity=True),
+    "optimizer": neps.Categorical(["adam", "sgd", "rmsprop"]),
+    "dropout_rate": neps.Constant(0.5),
 }
 
-neps.run(.., pipeline_space=pipeline_space)
+neps.run(.., pipeline_space = pipeline_space)
 ```
 
 ??? example "Quick Parameter Reference"
 
-    === "`CategoricalParameter`"
+    === "`Categorical`"
 
-        ::: neps.search_spaces.hyperparameters.categorical.CategoricalParameter
+        ::: neps.search_spaces.hyperparameters.categorical.Categorical
 
     === "`Float`"
 
         ::: neps.search_spaces.hyperparameters.float.Float
 
-    === "`IntegerParameter`"
+    === "`Integer`"
 
-        ::: neps.search_spaces.hyperparameters.integer.IntegerParameter
+        ::: neps.search_spaces.hyperparameters.integer.Integer
 
-    === "`ConstantParameter`"
+    === "`Constant`"
 
-        ::: neps.search_spaces.hyperparameters.constant.ConstantParameter
+        ::: neps.search_spaces.hyperparameters.constant.Constant
 
 
 ## Using your knowledge, providing a Prior
@@ -71,9 +71,9 @@ neps.run(
     ...,
     pipeline_space={
         "learning_rate": neps.Float(1e-4, 1e-1, log=True, default=1e-2, default_confidence="medium"),
-        "num_epochs": neps.IntegerParameter(3, 30, is_fidelity=True),
-        "optimizer": neps.CategoricalParameter(["adam", "sgd", "rmsprop"], default="adam", default_confidence="low"),
-        "dropout_rate": neps.ConstantParameter(0.5),
+        "num_epochs": neps.Integer(3, 30, is_fidelity=True),
+        "optimizer": neps.Categorical(["adam", "sgd", "rmsprop"], default="adam", default_confidence="low"),
+        "dropout_rate": neps.Constant(0.5),
     }
 )
 ```

--- a/docs/reference/pipeline_space.md
+++ b/docs/reference/pipeline_space.md
@@ -13,7 +13,7 @@ effectively incorporate various parameter types, ensuring that NePS can utilize 
 NePS currently features 4 primary hyperparameter types:
 
 * [`CategoricalParameter`][neps.search_spaces.hyperparameters.categorical.CategoricalParameter]
-* [`FloatParameter`][neps.search_spaces.hyperparameters.float.FloatParameter]
+* [`Float`][neps.search_spaces.hyperparameters.float.Float]
 * [`IntegerParameter`][neps.search_spaces.hyperparameters.integer.IntegerParameter]
 * [`ConstantParameter`][neps.search_spaces.hyperparameters.constant.ConstantParameter]
 
@@ -25,7 +25,7 @@ for optimizing a deep learning model:
 
 ```python
 pipeline_space = {
-    "learning_rate": neps.FloatParameter(0.00001, 0.1, log=True),
+    "learning_rate": neps.Float(0.00001, 0.1, log=True),
     "num_epochs": neps.IntegerParameter(3, 30, is_fidelity=True),
     "optimizer": neps.CategoricalParameter(["adam", "sgd", "rmsprop"]),
     "dropout_rate": neps.ConstantParameter(0.5),
@@ -40,9 +40,9 @@ neps.run(.., pipeline_space=pipeline_space)
 
         ::: neps.search_spaces.hyperparameters.categorical.CategoricalParameter
 
-    === "`FloatParameter`"
+    === "`Float`"
 
-        ::: neps.search_spaces.hyperparameters.float.FloatParameter
+        ::: neps.search_spaces.hyperparameters.float.Float
 
     === "`IntegerParameter`"
 
@@ -70,7 +70,7 @@ import neps
 neps.run(
     ...,
     pipeline_space={
-        "learning_rate": neps.FloatParameter(1e-4, 1e-1, log=True, default=1e-2, default_confidence="medium"),
+        "learning_rate": neps.Float(1e-4, 1e-1, log=True, default=1e-2, default_confidence="medium"),
         "num_epochs": neps.IntegerParameter(3, 30, is_fidelity=True),
         "optimizer": neps.CategoricalParameter(["adam", "sgd", "rmsprop"], default="adam", default_confidence="low"),
         "dropout_rate": neps.ConstantParameter(0.5),

--- a/neps/__init__.py
+++ b/neps/__init__.py
@@ -2,8 +2,11 @@ from neps.api import run
 from neps.plot.plot import plot
 from neps.plot.tensorboard_eval import tblogger
 from neps.search_spaces import (
+    Architecture,
     ArchitectureParameter,
+    Categorical,
     CategoricalParameter,
+    Constant,
     ConstantParameter,
     Float,
     FloatParameter,
@@ -11,14 +14,10 @@ from neps.search_spaces import (
     GraphGrammar,
     GraphGrammarCell,
     GraphGrammarRepetitive,
+    Integer,
     IntegerParameter,
 )
 from neps.status.status import get_summary_dict, status
-
-Integer = IntegerParameter
-Categorical = CategoricalParameter
-Constant = ConstantParameter
-Architecture = ArchitectureParameter
 
 __all__ = [
     "Architecture",

--- a/neps/__init__.py
+++ b/neps/__init__.py
@@ -5,6 +5,7 @@ from neps.search_spaces import (
     ArchitectureParameter,
     CategoricalParameter,
     ConstantParameter,
+    Float,
     FloatParameter,
     FunctionParameter,
     GraphGrammar,
@@ -15,7 +16,6 @@ from neps.search_spaces import (
 from neps.status.status import get_summary_dict, status
 
 Integer = IntegerParameter
-Float = FloatParameter
 Categorical = CategoricalParameter
 Constant = ConstantParameter
 Architecture = ArchitectureParameter

--- a/neps/api.py
+++ b/neps/api.py
@@ -122,7 +122,7 @@ def run(
         >>>    validation_error = -some_parameter
         >>>    return validation_error
 
-        >>> pipeline_space = dict(some_parameter=neps.FloatParameter(lower=0, upper=1))
+        >>> pipeline_space = dict(some_parameter=neps.Float(lower=0, upper=1))
 
         >>> logging.basicConfig(level=logging.INFO)
         >>> neps.run(

--- a/neps/optimizers/bayesian_optimization/kernels/get_kernels.py
+++ b/neps/optimizers/bayesian_optimization/kernels/get_kernels.py
@@ -1,8 +1,8 @@
 from neps.utils.common import instance_from_map
 from ....search_spaces.architecture.core_graph_grammar import CoreGraphGrammar
-from ....search_spaces.hyperparameters.categorical import CategoricalParameter
+from ....search_spaces.hyperparameters.categorical import Categorical
 from ....search_spaces.hyperparameters.float import Float
-from ....search_spaces.hyperparameters.integer import IntegerParameter
+from ....search_spaces.hyperparameters.integer import Integer
 from ....utils.common import has_instance
 from . import GraphKernelMapping, StationaryKernelMapping
 
@@ -16,9 +16,9 @@ def get_kernels(
             graph_kernels.append("wl")
     if not hp_kernels:
         hp_kernels = []
-        if has_instance(pipeline_space.values(), Float, IntegerParameter):
+        if has_instance(pipeline_space.values(), Float, Integer):
             hp_kernels.append("m52")
-        if has_instance(pipeline_space.values(), CategoricalParameter):
+        if has_instance(pipeline_space.values(), Categorical):
             hp_kernels.append("hm")
     graph_kernels = [
         instance_from_map(GraphKernelMapping, kernel, "kernel", as_class=True)(

--- a/neps/optimizers/bayesian_optimization/kernels/get_kernels.py
+++ b/neps/optimizers/bayesian_optimization/kernels/get_kernels.py
@@ -1,7 +1,7 @@
 from neps.utils.common import instance_from_map
 from ....search_spaces.architecture.core_graph_grammar import CoreGraphGrammar
 from ....search_spaces.hyperparameters.categorical import CategoricalParameter
-from ....search_spaces.hyperparameters.float import FloatParameter
+from ....search_spaces.hyperparameters.float import Float
 from ....search_spaces.hyperparameters.integer import IntegerParameter
 from ....utils.common import has_instance
 from . import GraphKernelMapping, StationaryKernelMapping
@@ -16,7 +16,7 @@ def get_kernels(
             graph_kernels.append("wl")
     if not hp_kernels:
         hp_kernels = []
-        if has_instance(pipeline_space.values(), FloatParameter, IntegerParameter):
+        if has_instance(pipeline_space.values(), Float, IntegerParameter):
             hp_kernels.append("m52")
         if has_instance(pipeline_space.values(), CategoricalParameter):
             hp_kernels.append("hm")

--- a/neps/optimizers/bayesian_optimization/mf_tpe.py
+++ b/neps/optimizers/bayesian_optimization/mf_tpe.py
@@ -13,7 +13,7 @@ from neps.utils.common import instance_from_map
 from neps.search_spaces import (
     CategoricalParameter,
     ConstantParameter,
-    FloatParameter,
+    Float,
     IntegerParameter,
     SearchSpace,
 )
@@ -26,7 +26,7 @@ from neps.optimizers.bayesian_optimization.acquisition_samplers.base_acq_sampler
 )
 from neps.optimizers.bayesian_optimization.models import SurrogateModelMapping
 
-CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(FloatParameter.DEFAULT_CONFIDENCE_SCORES)
+CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(Float.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
@@ -213,7 +213,7 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
         for k in self.pipeline_space.keys():
             if self.pipeline_space[k].is_fidelity:
                 continue
-            elif isinstance(self.pipeline_space[k], (FloatParameter, IntegerParameter)):
+            elif isinstance(self.pipeline_space[k], (Float, IntegerParameter)):
                 confidence = CUSTOM_FLOAT_CONFIDENCE_SCORES[self.prior_confidence]
                 self.pipeline_space[k].default_confidence_score = confidence
             elif isinstance(self.pipeline_space[k], CategoricalParameter):
@@ -269,7 +269,7 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
                 types.append("o")
                 logs.append(False)
                 num_values.append(hp.upper - hp.lower + 1)
-            elif isinstance(hp, FloatParameter):
+            elif isinstance(hp, Float):
                 # c as in continous
                 types.append("f")
                 logs.append(hp.log)

--- a/neps/optimizers/bayesian_optimization/mf_tpe.py
+++ b/neps/optimizers/bayesian_optimization/mf_tpe.py
@@ -11,10 +11,10 @@ from neps.state.optimizer import BudgetInfo, OptimizationState
 from neps.utils.types import ConfigResult, RawConfig
 from neps.utils.common import instance_from_map
 from neps.search_spaces import (
-    CategoricalParameter,
-    ConstantParameter,
+    Categorical,
+    Constant,
     Float,
-    IntegerParameter,
+    Integer,
     SearchSpace,
 )
 from neps.optimizers.base_optimizer import BaseOptimizer
@@ -30,7 +30,7 @@ CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(Float.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
-    CategoricalParameter.DEFAULT_CONFIDENCE_SCORES
+    Categorical.DEFAULT_CONFIDENCE_SCORES
 )
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES.update({"ultra": 8})
 
@@ -213,10 +213,10 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
         for k in self.pipeline_space.keys():
             if self.pipeline_space[k].is_fidelity:
                 continue
-            elif isinstance(self.pipeline_space[k], (Float, IntegerParameter)):
+            elif isinstance(self.pipeline_space[k], (Float, Integer)):
                 confidence = CUSTOM_FLOAT_CONFIDENCE_SCORES[self.prior_confidence]
                 self.pipeline_space[k].default_confidence_score = confidence
-            elif isinstance(self.pipeline_space[k], CategoricalParameter):
+            elif isinstance(self.pipeline_space[k], Categorical):
                 confidence = CUSTOM_CATEGORICAL_CONFIDENCE_SCORES[self.prior_confidence]
                 self.pipeline_space[k].default_confidence_score = confidence
 
@@ -235,7 +235,7 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
             # TODO: add +s to keys and TEST
             rung_value = (
                 int(_max_budget)
-                if isinstance(self.pipeline_space.fidelity, IntegerParameter)
+                if isinstance(self.pipeline_space.fidelity, Integer)
                 else _max_budget
             )
 
@@ -259,12 +259,12 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
         is_fidelity = []
         for _, hp in self.pipeline_space.items():
             is_fidelity.append(hp.is_fidelity)
-            if isinstance(hp, CategoricalParameter):
+            if isinstance(hp, Categorical):
                 # u as in unordered - used to play nice with the statsmodels KDE implementation
                 types.append("u")
                 logs.append(False)
                 num_values.append(len(hp.choices))
-            elif isinstance(hp, IntegerParameter):
+            elif isinstance(hp, Integer):
                 # o as in ordered
                 types.append("o")
                 logs.append(False)
@@ -274,7 +274,7 @@ class MultiFidelityPriorWeightedTreeParzenEstimator(BaseOptimizer):
                 types.append("f")
                 logs.append(hp.log)
                 num_values.append(np.inf)
-            elif isinstance(hp, ConstantParameter):
+            elif isinstance(hp, Constant):
                 # c as in continous
                 types.append("c")
                 logs.append(False)

--- a/neps/optimizers/bayesian_optimization/optimizer.py
+++ b/neps/optimizers/bayesian_optimization/optimizer.py
@@ -10,7 +10,7 @@ from neps.utils.common import instance_from_map
 from neps.search_spaces import (
     CategoricalParameter,
     ConstantParameter,
-    FloatParameter,
+    Float,
     IntegerParameter,
     SearchSpace,
 )
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     )
 
 # TODO(eddiebergman): Why not just include in the definition of the parameters.
-CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(FloatParameter.DEFAULT_CONFIDENCE_SCORES)
+CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(Float.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
@@ -208,7 +208,7 @@ class BayesianOptimization(BaseOptimizer):
         for k, v in self.pipeline_space.items():
             if v.is_fidelity or isinstance(v, ConstantParameter):
                 continue
-            elif isinstance(v, (FloatParameter, IntegerParameter)):
+            elif isinstance(v, (Float, IntegerParameter)):
                 if confidence_score is None:
                     confidence = CUSTOM_FLOAT_CONFIDENCE_SCORES[self.prior_confidence]
                 else:

--- a/neps/optimizers/bayesian_optimization/optimizer.py
+++ b/neps/optimizers/bayesian_optimization/optimizer.py
@@ -8,10 +8,10 @@ from neps.state.optimizer import BudgetInfo
 from neps.utils.types import ConfigResult, RawConfig
 from neps.utils.common import instance_from_map
 from neps.search_spaces import (
-    CategoricalParameter,
-    ConstantParameter,
+    Categorical,
+    Constant,
     Float,
-    IntegerParameter,
+    Integer,
     SearchSpace,
 )
 from neps.optimizers.base_optimizer import BaseOptimizer
@@ -38,7 +38,7 @@ CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(Float.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
-    CategoricalParameter.DEFAULT_CONFIDENCE_SCORES
+    Categorical.DEFAULT_CONFIDENCE_SCORES
 )
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES.update({"ultra": 8})
 
@@ -206,15 +206,15 @@ class BayesianOptimization(BaseOptimizer):
         ):
             return
         for k, v in self.pipeline_space.items():
-            if v.is_fidelity or isinstance(v, ConstantParameter):
+            if v.is_fidelity or isinstance(v, Constant):
                 continue
-            elif isinstance(v, (Float, IntegerParameter)):
+            elif isinstance(v, (Float, Integer)):
                 if confidence_score is None:
                     confidence = CUSTOM_FLOAT_CONFIDENCE_SCORES[self.prior_confidence]
                 else:
                     confidence = confidence_score["numeric"]
                 self.pipeline_space[k].default_confidence_score = confidence
-            elif isinstance(v, CategoricalParameter):
+            elif isinstance(v, Categorical):
                 if confidence_score is None:
                     confidence = CUSTOM_CATEGORICAL_CONFIDENCE_SCORES[
                         self.prior_confidence

--- a/neps/optimizers/multi_fidelity/ifbo.py
+++ b/neps/optimizers/multi_fidelity/ifbo.py
@@ -8,7 +8,7 @@ import warnings
 from neps.state.optimizer import BudgetInfo
 from neps.utils.types import ConfigResult
 from neps.utils.common import instance_from_map
-from neps.search_spaces.search_space import FloatParameter, IntegerParameter, SearchSpace
+from neps.search_spaces.search_space import Float, IntegerParameter, SearchSpace
 from neps.optimizers.base_optimizer import BaseOptimizer
 from neps.optimizers.bayesian_optimization.acquisition_functions import AcquisitionMapping
 from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
@@ -221,7 +221,7 @@ class IFBO(BaseOptimizer):
             budget_val = int(
                 self.step_size * budget_level + self.pipeline_space.fidelity.lower
             )
-        elif isinstance(self.pipeline_space.fidelity, FloatParameter):
+        elif isinstance(self.pipeline_space.fidelity, Float):
             budget_val = (
                 self.step_size * budget_level + self.pipeline_space.fidelity.lower
             )
@@ -229,7 +229,7 @@ class IFBO(BaseOptimizer):
             raise NotImplementedError(
                 f"Fidelity parameter: {self.pipeline_space.fidelity}"
                 f"must be one of the types: "
-                f"[IntegerParameter, FloatParameter], but is type:"
+                f"[IntegerParameter, Float], but is type:"
                 f"{type(self.pipeline_space.fidelity)}"
             )
         self._budget_list.append(budget_val)

--- a/neps/optimizers/multi_fidelity/ifbo.py
+++ b/neps/optimizers/multi_fidelity/ifbo.py
@@ -8,7 +8,7 @@ import warnings
 from neps.state.optimizer import BudgetInfo
 from neps.utils.types import ConfigResult
 from neps.utils.common import instance_from_map
-from neps.search_spaces.search_space import Float, IntegerParameter, SearchSpace
+from neps.search_spaces.search_space import Float, Integer, SearchSpace
 from neps.optimizers.base_optimizer import BaseOptimizer
 from neps.optimizers.bayesian_optimization.acquisition_functions import AcquisitionMapping
 from neps.optimizers.bayesian_optimization.acquisition_functions.base_acquisition import (
@@ -217,7 +217,7 @@ class IFBO(BaseOptimizer):
         )
 
     def get_budget_value(self, budget_level: int | float) -> int | float:
-        if isinstance(self.pipeline_space.fidelity, IntegerParameter):
+        if isinstance(self.pipeline_space.fidelity, Integer):
             budget_val = int(
                 self.step_size * budget_level + self.pipeline_space.fidelity.lower
             )
@@ -229,7 +229,7 @@ class IFBO(BaseOptimizer):
             raise NotImplementedError(
                 f"Fidelity parameter: {self.pipeline_space.fidelity}"
                 f"must be one of the types: "
-                f"[IntegerParameter, Float], but is type:"
+                f"[Integer, Float], but is type:"
                 f"{type(self.pipeline_space.fidelity)}"
             )
         self._budget_list.append(budget_val)

--- a/neps/optimizers/multi_fidelity/successive_halving.py
+++ b/neps/optimizers/multi_fidelity/successive_halving.py
@@ -14,7 +14,7 @@ from neps.utils.types import ConfigResult, RawConfig
 from neps.search_spaces import (
     CategoricalParameter,
     ConstantParameter,
-    FloatParameter,
+    Float,
     IntegerParameter,
     SearchSpace,
 )
@@ -28,7 +28,7 @@ from neps.optimizers.multi_fidelity.sampling_policy import (
     RandomUniformPolicy,
 )
 
-CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(FloatParameter.DEFAULT_CONFIDENCE_SCORES)
+CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(Float.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
@@ -459,7 +459,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
         for k, v in self.pipeline_space.items():
             if v.is_fidelity or isinstance(v, ConstantParameter):
                 continue
-            elif isinstance(v, (FloatParameter, IntegerParameter)):
+            elif isinstance(v, (Float, IntegerParameter)):
                 if confidence_score is None:
                     confidence = CUSTOM_FLOAT_CONFIDENCE_SCORES[self.prior_confidence]
                 else:

--- a/neps/optimizers/multi_fidelity/successive_halving.py
+++ b/neps/optimizers/multi_fidelity/successive_halving.py
@@ -12,10 +12,10 @@ from typing_extensions import override
 
 from neps.utils.types import ConfigResult, RawConfig
 from neps.search_spaces import (
-    CategoricalParameter,
-    ConstantParameter,
+    Categorical,
+    Constant,
     Float,
-    IntegerParameter,
+    Integer,
     SearchSpace,
 )
 from neps.optimizers.base_optimizer import BaseOptimizer
@@ -32,7 +32,7 @@ CUSTOM_FLOAT_CONFIDENCE_SCORES = dict(Float.DEFAULT_CONFIDENCE_SCORES)
 CUSTOM_FLOAT_CONFIDENCE_SCORES.update({"ultra": 0.05})
 
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES = dict(
-    CategoricalParameter.DEFAULT_CONFIDENCE_SCORES
+    Categorical.DEFAULT_CONFIDENCE_SCORES
 )
 CUSTOM_CATEGORICAL_CONFIDENCE_SCORES.update({"ultra": 8})
 
@@ -190,7 +190,7 @@ class SuccessiveHalvingBase(BaseOptimizer):
         for i in reversed(range(nrungs)):
             rung_map[i + s] = (
                 int(_max_budget)
-                if isinstance(self.pipeline_space.fidelity, IntegerParameter)
+                if isinstance(self.pipeline_space.fidelity, Integer)
                 else _max_budget
             )
             _max_budget /= self.eta
@@ -457,15 +457,15 @@ class SuccessiveHalvingBase(BaseOptimizer):
         if not self.use_priors and self.prior_confidence is None:
             return
         for k, v in self.pipeline_space.items():
-            if v.is_fidelity or isinstance(v, ConstantParameter):
+            if v.is_fidelity or isinstance(v, Constant):
                 continue
-            elif isinstance(v, (Float, IntegerParameter)):
+            elif isinstance(v, (Float, Integer)):
                 if confidence_score is None:
                     confidence = CUSTOM_FLOAT_CONFIDENCE_SCORES[self.prior_confidence]
                 else:
                     confidence = confidence_score["numeric"]
                 self.pipeline_space[k].default_confidence_score = confidence
-            elif isinstance(v, CategoricalParameter):
+            elif isinstance(v, Categorical):
                 if confidence_score is None:
                     confidence = CUSTOM_CATEGORICAL_CONFIDENCE_SCORES[
                         self.prior_confidence

--- a/neps/optimizers/multi_fidelity_prior/utils.py
+++ b/neps/optimizers/multi_fidelity_prior/utils.py
@@ -3,9 +3,9 @@ import pandas as pd
 import scipy
 
 from neps.search_spaces import (
-    CategoricalParameter,
-    ConstantParameter,
-    NumericalParameter,
+    Categorical,
+    Constant,
+    Numerical,
     Parameter,
     GraphParameter,
     SearchSpace,
@@ -36,7 +36,7 @@ def local_mutation(
             if hp.is_fidelity or np.random.uniform() > mutation_rate:
                 new_config[hp_name] = hp.clone()
 
-            elif isinstance(hp, CategoricalParameter):
+            elif isinstance(hp, Categorical):
                 if mutate_categoricals:
                     new_config[hp_name] = hp.mutate(mutation_strategy="local_search")
                 else:
@@ -48,12 +48,12 @@ def local_mutation(
                 else:
                     new_config[hp_name] = hp.clone()
 
-            elif isinstance(hp, NumericalParameter):
+            elif isinstance(hp, Numerical):
                 new_config[hp_name] = hp.mutate(
                     mutation_strategy="local_search",
                     std=std,
                 )
-            elif isinstance(hp, ConstantParameter):
+            elif isinstance(hp, Constant):
                 new_config[hp_name] = hp.clone()
 
             else:

--- a/neps/search_spaces/__init__.py
+++ b/neps/search_spaces/__init__.py
@@ -8,6 +8,7 @@ from neps.search_spaces.architecture.graph_grammar import (
 from neps.search_spaces.hyperparameters import (
     CategoricalParameter,
     ConstantParameter,
+    Float,
     FloatParameter,
     IntegerParameter,
     NumericalParameter,
@@ -23,6 +24,7 @@ __all__ = [
     "ArchitectureParameter",
     "CategoricalParameter",
     "ConstantParameter",
+    "Float",
     "FloatParameter",
     "FunctionParameter",
     "GraphGrammar",

--- a/neps/search_spaces/__init__.py
+++ b/neps/search_spaces/__init__.py
@@ -1,16 +1,26 @@
-from neps.search_spaces.architecture.api import ArchitectureParameter, FunctionParameter
+from neps.search_spaces.architecture.api import (
+    Architecture,
+    ArchitectureParameter,
+    FunctionParameter,
+)
 from neps.search_spaces.architecture.graph_grammar import (
     GraphGrammar,
     GraphGrammarCell,
     GraphGrammarRepetitive,
     GraphParameter,
 )
+
+# categorical, constant, float, integer, numerical
 from neps.search_spaces.hyperparameters import (
+    Categorical,
     CategoricalParameter,
+    Constant,
     ConstantParameter,
     Float,
     FloatParameter,
+    Integer,
     IntegerParameter,
+    Numerical,
     NumericalParameter,
 )
 from neps.search_spaces.parameter import (
@@ -21,10 +31,15 @@ from neps.search_spaces.parameter import (
 from neps.search_spaces.search_space import SearchSpace
 
 __all__ = [
+    "Architecture",
+    "Categorical",
+    "Constant",
+    "Float",
+    "Integer",
+    "Numerical",
     "ArchitectureParameter",
     "CategoricalParameter",
     "ConstantParameter",
-    "Float",
     "FloatParameter",
     "FunctionParameter",
     "GraphGrammar",

--- a/neps/search_spaces/architecture/api.py
+++ b/neps/search_spaces/architecture/api.py
@@ -49,7 +49,7 @@ def _build(graph, set_recursive_attribute):
             graph.edges[e].update(set_recursive_attribute(op_name, predecessor_values))
 
 
-def ArchitectureParameter(**kwargs):
+def Architecture(**kwargs):
     """Factory function"""
 
     if "structure" not in kwargs:
@@ -160,11 +160,31 @@ def ArchitectureParameter(**kwargs):
             return composed_function(inputs)
 
         def create_new_instance_from_id(self, identifier: str):
-            g = ArchitectureParameter(**self.input_kwargs)  # type: ignore[arg-type]
+            g = Architecture(**self.input_kwargs)  # type: ignore[arg-type]
             g.load_from(identifier)
             return g
 
     return _FunctionParameter(**kwargs)
 
 
-FunctionParameter = ArchitectureParameter
+def ArchitectureParameter(**kwargs):
+    """Deprecated: Use `Architecture` instead of `ArchitectureParameter`.
+
+    This class remains for backward compatibility and will raise a deprecation
+    warning if used.
+    """
+
+    import warnings
+
+    warnings.warn(
+        (
+            "The usage of 'neps.ArchitectureParameter' is deprecated and will be removed"
+            " in future releases. Please use 'neps.Architecture' instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return Architecture(**kwargs)
+
+
+FunctionParameter = Architecture

--- a/neps/search_spaces/hyperparameters/__init__.py
+++ b/neps/search_spaces/hyperparameters/__init__.py
@@ -1,14 +1,21 @@
-from neps.search_spaces.hyperparameters.categorical import CategoricalParameter
-from neps.search_spaces.hyperparameters.constant import ConstantParameter
+from neps.search_spaces.hyperparameters.categorical import (
+    Categorical,
+    CategoricalParameter,
+)
+from neps.search_spaces.hyperparameters.constant import Constant, ConstantParameter
 from neps.search_spaces.hyperparameters.float import Float, FloatParameter
-from neps.search_spaces.hyperparameters.integer import IntegerParameter
-from neps.search_spaces.hyperparameters.numerical import NumericalParameter
+from neps.search_spaces.hyperparameters.integer import Integer, IntegerParameter
+from neps.search_spaces.hyperparameters.numerical import Numerical, NumericalParameter
 
 __all__ = [
+    "Categorical",
+    "Constant",
+    "Float",
+    "Integer",
+    "Numerical",
     "CategoricalParameter",
     "ConstantParameter",
-    "IntegerParameter",
-    "Float",
     "FloatParameter",
+    "IntegerParameter",
     "NumericalParameter",
 ]

--- a/neps/search_spaces/hyperparameters/__init__.py
+++ b/neps/search_spaces/hyperparameters/__init__.py
@@ -1,6 +1,6 @@
 from neps.search_spaces.hyperparameters.categorical import CategoricalParameter
 from neps.search_spaces.hyperparameters.constant import ConstantParameter
-from neps.search_spaces.hyperparameters.float import FloatParameter
+from neps.search_spaces.hyperparameters.float import Float, FloatParameter
 from neps.search_spaces.hyperparameters.integer import IntegerParameter
 from neps.search_spaces.hyperparameters.numerical import NumericalParameter
 
@@ -8,6 +8,7 @@ __all__ = [
     "CategoricalParameter",
     "ConstantParameter",
     "IntegerParameter",
+    "Float",
     "FloatParameter",
     "NumericalParameter",
 ]

--- a/neps/search_spaces/hyperparameters/categorical.py
+++ b/neps/search_spaces/hyperparameters/categorical.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 CategoricalTypes: TypeAlias = float | int | str
 
 
-class CategoricalParameter(
+class Categorical(
     ParameterWithPrior[CategoricalTypes, CategoricalTypes],
     MutatableParameter,
 ):
@@ -27,13 +27,13 @@ class CategoricalParameter(
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
     to represent hyperparameters that can take on a discrete set of unordered
     values. For example, the `optimizer` hyperparameter in a neural network
-    search space can be a `CategoricalParameter` with choices like
+    search space can be a `Categorical` parameter with choices like
     `#!python ["adam", "sgd", "rmsprop"]`.
 
     ```python
     import neps
 
-    optimizer_choice = neps.CategoricalParameter(
+    optimizer_choice = neps.Categorical(
         ["adam", "sgd", "rmsprop"],
         default="adam"
     )
@@ -58,7 +58,7 @@ class CategoricalParameter(
         default: float | int | str | None = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
-        """Create a new `CategoricalParameter`.
+        """Create a new `Categorical` parameter.
 
         Args:
             choices: choices for the hyperparameter.
@@ -279,3 +279,53 @@ class CategoricalParameter(
     @classmethod
     def deserialize_value(cls, value: CategoricalTypes) -> CategoricalTypes:
         return value
+
+
+class CategoricalParameter(Categorical):
+    """Deprecated: Use `Categorical` instead of `CategoricalParameter`.
+
+    This class was previously used to represent categorical hyperparameters in
+    search spaces, but it has been replaced by the `Categorical` class. It is recommended
+    to update your code to use `Categorical`, which offers the same functionality with
+    a cleaner interface.
+
+    This class remains for backward compatibility and will raise a deprecation
+    warning if used.
+    """
+
+    def __init__(
+        self,
+        choices: Iterable[float | int | str],
+        *,
+        default: float | int | str | None = None,
+        default_confidence: Literal["low", "medium", "high"] = "low",
+    ):
+        """Initialize a deprecated `CategoricalParameter`.
+
+        Args:
+            choices: choices for the hyperparameter.
+            default: default value for the hyperparameter, must be in `choices=`
+                if provided.
+            default_confidence: confidence score for the default value, used when
+                condsider prior based optimization.
+
+        Raises:
+            DeprecationWarning: A warning indicating that `CategoricalParameter` is
+            deprecated and the `Categorical` class should be used instead.
+        """
+        import warnings
+
+        warnings.warn(
+            (
+                "The usage of 'neps.CategoricalParameter' is deprecated and will be"
+                " removed in future releases. Please use 'neps.Categorical' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        super().__init__(
+            choices=choices,
+            default=default,
+            default_confidence=default_confidence,
+        )

--- a/neps/search_spaces/hyperparameters/constant.py
+++ b/neps/search_spaces/hyperparameters/constant.py
@@ -10,23 +10,23 @@ from neps.search_spaces.parameter import Parameter
 T = TypeVar("T", int, float, str)
 
 
-class ConstantParameter(Parameter[T, T]):
+class Constant(Parameter[T, T]):
     """A constant value for a parameter.
 
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
     to represent hyperparameters with values that should not change during
     optimization. For example, the `batch_size` hyperparameter in a neural
-    network search space can be a `ConstantParameter` with a value of `32`.
+    network search space can be a `Constant` parameter with a value of `32`.
 
     ```python
     import neps
 
-    batch_size = neps.ConstantParameter(32)
+    batch_size = neps.Constant(32)
     ```
 
     !!! note
 
-        As the name suggests, the value of a `ConstantParameter` only have one
+        As the name suggests, the value of a `Constant` only have one
         value and so its [`.default`][neps.search_spaces.parameter.Parameter.default]
         and [`.value`][neps.search_spaces.parameter.Parameter.value] should always be
         the same.
@@ -35,13 +35,13 @@ class ConstantParameter(Parameter[T, T]):
         [`.default`][neps.search_spaces.parameter.Parameter.default] can never be `None`.
 
         Please use
-        [`.set_constant_value()`][neps.search_spaces.hyperparameters.constant.ConstantParameter.set_constant_value]
+        [`.set_constant_value()`][neps.search_spaces.hyperparameters.constant.Constant.set_constant_value]
         if you need to change the value of the constant parameter.
 
     """
 
     def __init__(self, value: T):
-        """Create a new `ConstantParameter`.
+        """Create a new `Constant`.
 
         Args:
             value: value for the hyperparameter.
@@ -82,7 +82,7 @@ class ConstantParameter(Parameter[T, T]):
             is different from the current default.
 
             Please see
-            [`.set_constant_value()`][neps.search_spaces.hyperparameters.constant.ConstantParameter.set_constant_value]
+            [`.set_constant_value()`][neps.search_spaces.hyperparameters.constant.Constant.set_constant_value]
             which can be used to set both the
             [`.value`][neps.search_spaces.parameter.Parameter.value]
             and the [`.default`][neps.search_spaces.parameter.Parameter.default] at once
@@ -109,7 +109,7 @@ class ConstantParameter(Parameter[T, T]):
             is different from the current value.
 
             Please see
-            [`.set_constant_value()`][neps.search_spaces.hyperparameters.constant.ConstantParameter.set_constant_value]
+            [`.set_constant_value()`][neps.search_spaces.hyperparameters.constant.Constant.set_constant_value]
             which can be used to set both the
             [`.value`][neps.search_spaces.parameter.Parameter.value]
             and the [`.default`][neps.search_spaces.parameter.Parameter.default] at once
@@ -154,7 +154,7 @@ class ConstantParameter(Parameter[T, T]):
         *,
         std: float = 0.2,
     ) -> list[Self]:
-        raise ValueError("ConstantParameter have no neighbours")
+        raise ValueError("Constant have no neighbours")
 
     @override
     @classmethod
@@ -165,3 +165,39 @@ class ConstantParameter(Parameter[T, T]):
     @classmethod
     def deserialize_value(cls, value: T) -> T:
         return value
+
+
+class ConstantParameter(Constant):
+    """Deprecated: Use `Constant` instead of `ConstantParameter`.
+
+    This class was previously used to represent constant hyperparameters in
+    search spaces, but it has been replaced by the `Constant` class. It is recommended
+    to update your code to use `Constant`, which offers the same functionality with
+    a cleaner interface.
+
+    This class remains for backward compatibility and will raise a deprecation
+    warning if used.
+    """
+
+    def __init__(self, value: T):
+        """Initialize a deprecated `ConstantParameter`.
+
+        Args:
+            value: value for the hyperparameter.
+
+        Raises:
+            DeprecationWarning: A warning indicating that `ConstantParameter` is
+            deprecated and the `Constant` class should be used instead.
+        """
+        import warnings
+
+        warnings.warn(
+            (
+                "The usage of 'neps.ConstantParameter' is deprecated and will be"
+                " removed in future releases. Please use 'neps.Constant' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        super().__init__(value=value)

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from neps.utils.types import Number
 
 
-class FloatParameter(NumericalParameter[float]):
+class Float(NumericalParameter[float]):
     """A float value for a parameter.
 
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
@@ -23,14 +23,14 @@ class FloatParameter(NumericalParameter[float]):
     it exists
     on a log scale.
     For example, `l2_norm` could be a value in `(0.1)`, while the `learning_rate`
-    hyperparameter in a neural network search space can be a `FloatParameter`
+    hyperparameter in a neural network search space can be a `Float`
     with a range of `(0.0001, 0.1)` but on a log scale.
 
     ```python
     import neps
 
-    l2_norm = neps.FloatParameter(0, 1)
-    learning_rate = neps.FloatParameter(1e-4, 1e-1, log=True)
+    l2_norm = neps.Float(0, 1)
+    learning_rate = neps.Float(1e-4, 1e-1, log=True)
     ```
 
     Please see the [`NumericalParameter`][neps.search_spaces.numerical.NumericalParameter]
@@ -53,7 +53,7 @@ class FloatParameter(NumericalParameter[float]):
         default: Number | None = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
-        """Create a new `FloatParameter`.
+        """Create a new `Float`.
 
         Args:
             lower: lower bound for the hyperparameter.
@@ -204,3 +204,60 @@ class FloatParameter(NumericalParameter[float]):
     def __repr__(self) -> str:
         float_repr = f"{self.value:.07f}" if self.value is not None else "None"
         return f"<Float, range: [{self.lower}, {self.upper}], value: {float_repr}>"
+
+
+class FloatParameter(Float):
+    """Deprecated: Use `Float` instead of `FloatParameter`.
+
+    This class was previously used to represent floating-point hyperparameters in
+    search spaces, but it has been replaced by the `Float` class. It is recommended
+    to update your code to use `Float`, which offers the same functionality with
+    a cleaner interface.
+
+    This class remains for backward compatibility and will raise a deprecation
+    warning if used.
+    """
+
+    def __init__(
+        self,
+        lower: Number,
+        upper: Number,
+        *,
+        log: bool = False,
+        is_fidelity: bool = False,
+        default: Number | None = None,
+        default_confidence: Literal["low", "medium", "high"] = "low",
+    ):
+        """Initialize a deprecated `FloatParameter`.
+
+        Args:
+            lower: lower bound for the hyperparameter.
+            upper: upper bound for the hyperparameter.
+            log: whether the hyperparameter is on a log scale.
+            is_fidelity: whether the hyperparameter is fidelity.
+            default: default value for the hyperparameter.
+            default_confidence: confidence score for the default value, used when
+                condsidering prior based optimization..
+
+        Raises:
+            DeprecationWarning: A warning indicating that `FloatParameter` is deprecated
+            and the `Float` class should be used instead.
+        """
+        import warnings
+
+        warnings.warn(
+            (
+                "The 'FloatParameter' class is deprecated and will be removed in future"
+                " releases. Please use 'Float' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            lower=lower,
+            upper=upper,
+            log=log,
+            is_fidelity=is_fidelity,
+            default=default,
+            default_confidence=default_confidence,
+        )

--- a/neps/search_spaces/hyperparameters/float.py
+++ b/neps/search_spaces/hyperparameters/float.py
@@ -9,13 +9,13 @@ from typing_extensions import Self, override
 
 import numpy as np
 
-from neps.search_spaces.hyperparameters.numerical import NumericalParameter
+from neps.search_spaces.hyperparameters.numerical import Numerical
 
 if TYPE_CHECKING:
     from neps.utils.types import Number
 
 
-class Float(NumericalParameter[float]):
+class Float(Numerical[float]):
     """A float value for a parameter.
 
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
@@ -23,7 +23,7 @@ class Float(NumericalParameter[float]):
     it exists
     on a log scale.
     For example, `l2_norm` could be a value in `(0.1)`, while the `learning_rate`
-    hyperparameter in a neural network search space can be a `Float`
+    hyperparameter in a neural network search space can be a `Float` parameter
     with a range of `(0.0001, 0.1)` but on a log scale.
 
     ```python
@@ -33,7 +33,7 @@ class Float(NumericalParameter[float]):
     learning_rate = neps.Float(1e-4, 1e-1, log=True)
     ```
 
-    Please see the [`NumericalParameter`][neps.search_spaces.numerical.NumericalParameter]
+    Please see the [`Numerical`][neps.search_spaces.numerical.Numerical]
     class for more details on the methods available for this class.
     """
 
@@ -247,8 +247,8 @@ class FloatParameter(Float):
 
         warnings.warn(
             (
-                "The 'FloatParameter' class is deprecated and will be removed in future"
-                " releases. Please use 'Float' instead."
+                "The usage of 'neps.FloatParameter' is deprecated and will be removed"
+                " in future releases. Please use 'neps.Float' instead."
             ),
             DeprecationWarning,
             stacklevel=2,

--- a/neps/search_spaces/hyperparameters/integer.py
+++ b/neps/search_spaces/hyperparameters/integer.py
@@ -8,7 +8,7 @@ from typing_extensions import Self, override
 
 import numpy as np
 
-from neps.search_spaces.hyperparameters.float import FloatParameter
+from neps.search_spaces.hyperparameters.float import Float
 from neps.search_spaces.hyperparameters.numerical import NumericalParameter
 
 if TYPE_CHECKING:
@@ -81,7 +81,7 @@ class IntegerParameter(NumericalParameter[int]):
         # We subtract/add 0.499999 from lower/upper bounds respectively, such that
         # sampling in the float space gives equal probability for all integer values,
         # i.e. [x - 0.499999, x + 0.499999]
-        self.float_hp = FloatParameter(
+        self.float_hp = Float(
             lower=self.lower - 0.499999,
             upper=self.upper + 0.499999,
             log=self.log,

--- a/neps/search_spaces/hyperparameters/integer.py
+++ b/neps/search_spaces/hyperparameters/integer.py
@@ -9,27 +9,27 @@ from typing_extensions import Self, override
 import numpy as np
 
 from neps.search_spaces.hyperparameters.float import Float
-from neps.search_spaces.hyperparameters.numerical import NumericalParameter
+from neps.search_spaces.hyperparameters.numerical import Numerical
 
 if TYPE_CHECKING:
     from neps.utils.types import Number
 
 
-class IntegerParameter(NumericalParameter[int]):
+class Integer(Numerical[int]):
     """An integer value for a parameter.
 
     This kind of [`Parameter`][neps.search_spaces.parameter] is used
     to represent hyperparameters with continuous integer values, optionally specifying
     f it exists on a log scale.
     For example, `batch_size` could be a value in `(32, 128)`, while the `num_layers`
-    hyperparameter in a neural network search space can be a `IntegerParameter`
+    hyperparameter in a neural network search space can be a `Integer` hyperparameter
     with a range of `(1, 1000)` but on a log scale.
 
     ```python
     import neps
 
-    batch_size = neps.IntegerParameter(32, 128)
-    num_layers = neps.IntegerParameter(1, 1000, log=True)
+    batch_size = neps.Integer(32, 128)
+    num_layers = neps.Integer(1, 1000, log=True)
     ```
     """
 
@@ -49,7 +49,7 @@ class IntegerParameter(NumericalParameter[int]):
         default: Number | None = None,
         default_confidence: Literal["low", "medium", "high"] = "low",
     ):
-        """Create a new `IntegerParameter`.
+        """Create a new `Integer`.
 
         Args:
             lower: lower bound for the hyperparameter.
@@ -65,7 +65,7 @@ class IntegerParameter(NumericalParameter[int]):
         _size = upper - lower + 1
         if _size <= 1:
             raise ValueError(
-                f"IntegerParameter: expected at least 2 possible values in the range,"
+                f"Integer: expected at least 2 possible values in the range,"
                 f" got upper={upper}, lower={lower}."
             )
 
@@ -195,3 +195,60 @@ class IntegerParameter(NumericalParameter[int]):
             neighbours.append(neighbour)
 
         return neighbours
+
+
+class IntegerParameter(Integer):
+    """Deprecated: Use `Integer` instead of `IntegerParameter`.
+
+    This class was previously used to represent integer hyperparameters in
+    search spaces, but it has been replaced by the `Integer` class. It is recommended
+    to update your code to use `Integer`, which offers the same functionality with
+    a cleaner interface.
+
+    This class remains for backward compatibility and will raise a deprecation
+    warning if used.
+    """
+
+    def __init__(
+        self,
+        lower: Number,
+        upper: Number,
+        *,
+        log: bool = False,
+        is_fidelity: bool = False,
+        default: Number | None = None,
+        default_confidence: Literal["low", "medium", "high"] = "low",
+    ):
+        """Initialize a deprecated `IntegerParameter`.
+
+        Args:
+            lower: lower bound for the hyperparameter.
+            upper: upper bound for the hyperparameter.
+            log: whether the hyperparameter is on a log scale.
+            is_fidelity: whether the hyperparameter is fidelity.
+            default: default value for the hyperparameter.
+            default_confidence: confidence score for the default value, used when
+                condsider prior based optimization.
+
+        Raises:
+            DeprecationWarning: A warning indicating that `IntegerParameter` is deprecated
+            and the `Float` class should be used instead.
+        """
+        import warnings
+
+        warnings.warn(
+            (
+                "The usage of 'neps.IntegerParameter' class is deprecated and will be"
+                " removed in future releases. Please use 'neps.Integer' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            lower=lower,
+            upper=upper,
+            log=log,
+            is_fidelity=is_fidelity,
+            default=default,
+            default_confidence=default_confidence,
+        )

--- a/neps/search_spaces/hyperparameters/numerical.py
+++ b/neps/search_spaces/hyperparameters/numerical.py
@@ -4,7 +4,7 @@ range.
 
 The two primary numerical hyperparameters are:
 
-* [`FloatParameter`][neps.search_spaces.FloatParameter] for continuous
+* [`Float`][neps.search_spaces.Float] for continuous
     float values.
 * [`IntegerParameter`][neps.search_spaces.IntegerParameter] for discrete
     integer values.
@@ -33,7 +33,7 @@ import scipy
 from neps.search_spaces.parameter import MutatableParameter, ParameterWithPrior
 
 if TYPE_CHECKING:
-    from neps.search_spaces.hyperparameters.float import FloatParameter
+    from neps.search_spaces.hyperparameters.float import Float
     from neps.search_spaces.hyperparameters.integer import IntegerParameter
     from neps.utils.types import TruncNorm
 
@@ -263,11 +263,11 @@ class NumericalParameter(ParameterWithPrior[T, T], MutatableParameter):
         int_hp.set_value(as_int(self.value) if self.value is not None else None)
         return int_hp
 
-    def to_float(self) -> FloatParameter:
+    def to_float(self) -> Float:
         """Convert the numerical hyperparameter to a float hyperparameter."""
-        from neps.search_spaces.hyperparameters.integer import FloatParameter
+        from neps.search_spaces.hyperparameters.integer import Float
 
-        float_hp = FloatParameter(
+        float_hp = Float(
             lower=float(self.lower),
             upper=float(self.upper),
             is_fidelity=self.is_fidelity,

--- a/neps/search_spaces/hyperparameters/numerical.py
+++ b/neps/search_spaces/hyperparameters/numerical.py
@@ -1,4 +1,4 @@
-"""The [`NumericalParameter`][neps.search_spaces.NumericalParameter] is
+"""The [`Numerical`][neps.search_spaces.Numerical] is
 a [`Parameter`][neps.search_spaces.Parameter] that represents a numerical
 range.
 
@@ -6,18 +6,18 @@ The two primary numerical hyperparameters are:
 
 * [`Float`][neps.search_spaces.Float] for continuous
     float values.
-* [`IntegerParameter`][neps.search_spaces.IntegerParameter] for discrete
+* [`Integer`][neps.search_spaces.Integer] for discrete
     integer values.
 
-The [`NumericalParameter`][neps.search_spaces.NumericalParameter] is a
+The [`Numerical`][neps.search_spaces.Numerical] is a
 base class for both of these hyperparameters, and includes methods from
 both [`ParameterWithPrior`][neps.search_spaces.ParameterWithPrior],
 allowing you to set a confidence along with a
 [`.default`][neps.search_spaces.Parameter.default] that can be used
 with certain algorithms, as well as
 [`MutatableParameter`][neps.search_spaces.MutatableParameter],
-which allows for [`mutate()`][neps.search_spaces.NumericalParameter.mutate]
-and [`crossover()`][neps.search_spaces.NumericalParameter.crossover] operations.
+which allows for [`mutate()`][neps.search_spaces.Numerical.mutate]
+and [`crossover()`][neps.search_spaces.Numerical.crossover] operations.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ from neps.search_spaces.parameter import MutatableParameter, ParameterWithPrior
 
 if TYPE_CHECKING:
     from neps.search_spaces.hyperparameters.float import Float
-    from neps.search_spaces.hyperparameters.integer import IntegerParameter
+    from neps.search_spaces.hyperparameters.integer import Integer
     from neps.utils.types import TruncNorm
 
 T = TypeVar("T", int, float)
@@ -56,7 +56,7 @@ def _get_truncnorm_prior_and_std(
     return scipy.stats.truncnorm(a, b), float(std)
 
 
-class NumericalParameter(ParameterWithPrior[T, T], MutatableParameter):
+class Numerical(ParameterWithPrior[T, T], MutatableParameter):
     """A numerical hyperparameter is bounded by a lower and upper value.
 
     Attributes:
@@ -247,13 +247,13 @@ class NumericalParameter(ParameterWithPrior[T, T], MutatableParameter):
             confidence_score=self.default_confidence_score,
         )
 
-    def to_integer(self) -> IntegerParameter:
+    def to_integer(self) -> Integer:
         """Convert the numerical hyperparameter to an integer hyperparameter."""
-        from neps.search_spaces.hyperparameters.integer import IntegerParameter
+        from neps.search_spaces.hyperparameters.integer import Integer
 
         as_int = lambda x: int(np.rint(x))
 
-        int_hp = IntegerParameter(
+        int_hp = Integer(
             lower=as_int(self.lower),
             upper=as_int(self.upper),
             is_fidelity=self.is_fidelity,
@@ -307,3 +307,59 @@ class NumericalParameter(ParameterWithPrior[T, T], MutatableParameter):
     @classmethod
     def deserialize_value(cls, value: T) -> T:
         return value
+
+
+class NumericalParameter(Numerical):
+    """Deprecated: Use `Numerical` instead of `NumericalParameter`.
+
+    This class was previously used to represent numerical hyperparameters in
+    search spaces, but it has been replaced by the `Numerical` class. It is recommended
+    to update your code to use `Numerical`, which offers the same functionality with
+    a cleaner interface.
+
+    This class remains for backward compatibility and will raise a deprecation
+    warning if used.
+    """
+
+    def __init__(
+        self,
+        lower: T,
+        upper: T,
+        *,
+        log: bool = False,
+        default: T | None,
+        is_fidelity: bool,
+        default_confidence: Literal["low", "medium", "high"] = "low",
+    ):
+        """Initialize a deprecated `NumericalParameter`.
+
+        Args:
+            lower: The lower bound of the numerical hyperparameter.
+            upper: The upper bound of the numerical hyperparameter.
+            log: Whether the hyperparameter is in log space.
+            default: The default value of the hyperparameter.
+            is_fidelity: Whether the hyperparameter is a fidelity parameter.
+            default_confidence: The default confidence choice.
+
+        Raises:
+            DeprecationWarning: A warning indicating that `NumericalParameter` is
+            deprecated and the `Numerical` class should be used instead.
+        """
+        import warnings
+
+        warnings.warn(
+            (
+                "The usage of 'neps.NumericalParameter' class is deprecated and will be"
+                " removed in future releases. Please use 'neps.Numerical' instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            lower=lower,
+            upper=upper,
+            log=log,
+            default=default,
+            is_fidelity=is_fidelity,
+            default_confidence=default_confidence,
+        )

--- a/neps/search_spaces/parameter.py
+++ b/neps/search_spaces/parameter.py
@@ -142,10 +142,10 @@ class Parameter(ABC, Generic[ValueT, SerializedT]):
         but roughly refers to numeric values.
 
         * `(0, 1)` scaling in the case of
-            a [`NumericalParameter`][neps.search_spaces.NumericalParameter],
-        * `{0.0, 1.0}` for a [`ConstantParameter`][neps.search_spaces.ConstantParameter],
+            a [`Numerical`][neps.search_spaces.Numerical],
+        * `{0.0, 1.0}` for a [`Constant`][neps.search_spaces.Constant],
         * `[0, 1, ..., n]` for a
-            [`Categorical`][neps.search_spaces.CategoricalParameter].
+            [`Categorical`][neps.search_spaces.Categorical].
 
         Args:
             value: value to convert.

--- a/neps/search_spaces/search_space.py
+++ b/neps/search_spaces/search_space.py
@@ -21,7 +21,7 @@ from neps.search_spaces.architecture.graph_grammar import GraphParameter
 from neps.search_spaces.hyperparameters import (
     CategoricalParameter,
     ConstantParameter,
-    FloatParameter,
+    Float,
     IntegerParameter,
     NumericalParameter,
 )
@@ -83,7 +83,7 @@ def pipeline_space_from_configspace(
                 default=hyperparameter.default_value,
             )
         elif isinstance(hyperparameter, CS.UniformFloatHyperparameter):
-            parameter = FloatParameter(
+            parameter = Float(
                 lower=hyperparameter.lower,
                 upper=hyperparameter.upper,
                 log=hyperparameter.log,
@@ -145,7 +145,7 @@ def pipeline_space_from_yaml(  # noqa: C901
                 pipeline_space[name] = IntegerParameter(**formatted_details)
             elif param_type == "float":
                 formatted_details = formatting_float(name, details)
-                pipeline_space[name] = FloatParameter(**formatted_details)
+                pipeline_space[name] = Float(**formatted_details)
             elif param_type in ("cat", "categorical"):
                 formatted_details = formatting_cat(name, details)
                 pipeline_space[name] = CategoricalParameter(**formatted_details)

--- a/neps_examples/basic_usage/architecture.py
+++ b/neps_examples/basic_usage/architecture.py
@@ -111,7 +111,7 @@ def run_pipeline(architecture):
 
 
 pipeline_space = dict(
-    architecture=neps.ArchitectureParameter(
+    architecture=neps.Architecture(
         set_recursive_attribute=set_recursive_attribute,
         structure=structure,
         primitives=primitives,

--- a/neps_examples/basic_usage/architecture_and_hyperparameters.py
+++ b/neps_examples/basic_usage/architecture_and_hyperparameters.py
@@ -110,7 +110,7 @@ pipeline_space = dict(
         primitives=primitives,
     ),
     optimizer=neps.CategoricalParameter(choices=["sgd", "adam"]),
-    learning_rate=neps.FloatParameter(lower=10e-7, upper=10e-3, log=True),
+    learning_rate=neps.Float(lower=10e-7, upper=10e-3, log=True),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/basic_usage/architecture_and_hyperparameters.py
+++ b/neps_examples/basic_usage/architecture_and_hyperparameters.py
@@ -104,12 +104,12 @@ def run_pipeline(**config):
 
 
 pipeline_space = dict(
-    architecture=neps.ArchitectureParameter(
+    architecture=neps.Architecture(
         set_recursive_attribute=set_recursive_attribute,
         structure=structure,
         primitives=primitives,
     ),
-    optimizer=neps.CategoricalParameter(choices=["sgd", "adam"]),
+    optimizer=neps.Categorical(choices=["sgd", "adam"]),
     learning_rate=neps.Float(lower=10e-7, upper=10e-3, log=True),
 )
 

--- a/neps_examples/basic_usage/hyperparameters.py
+++ b/neps_examples/basic_usage/hyperparameters.py
@@ -13,8 +13,8 @@ def run_pipeline(float1, float2, categorical, integer1, integer2):
 
 
 pipeline_space = dict(
-    float1=neps.FloatParameter(lower=0, upper=1),
-    float2=neps.FloatParameter(lower=-10, upper=10),
+    float1=neps.Float(lower=0, upper=1),
+    float2=neps.Float(lower=-10, upper=10),
     categorical=neps.CategoricalParameter(choices=[0, 1]),
     integer1=neps.IntegerParameter(lower=0, upper=1),
     integer2=neps.IntegerParameter(lower=1, upper=1000, log=True),

--- a/neps_examples/basic_usage/hyperparameters.py
+++ b/neps_examples/basic_usage/hyperparameters.py
@@ -15,9 +15,9 @@ def run_pipeline(float1, float2, categorical, integer1, integer2):
 pipeline_space = dict(
     float1=neps.Float(lower=0, upper=1),
     float2=neps.Float(lower=-10, upper=10),
-    categorical=neps.CategoricalParameter(choices=[0, 1]),
-    integer1=neps.IntegerParameter(lower=0, upper=1),
-    integer2=neps.IntegerParameter(lower=1, upper=1000, log=True),
+    categorical=neps.Categorical(choices=[0, 1]),
+    integer1=neps.Integer(lower=0, upper=1),
+    integer2=neps.Integer(lower=1, upper=1000, log=True),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/convenience/logging_additional_info.py
+++ b/neps_examples/convenience/logging_additional_info.py
@@ -19,8 +19,8 @@ def run_pipeline(float1, float2, categorical, integer1, integer2):
 
 
 pipeline_space = dict(
-    float1=neps.FloatParameter(lower=0, upper=1),
-    float2=neps.FloatParameter(lower=-10, upper=10),
+    float1=neps.Float(lower=0, upper=1),
+    float2=neps.Float(lower=-10, upper=10),
     categorical=neps.CategoricalParameter(choices=[0, 1]),
     integer1=neps.IntegerParameter(lower=0, upper=1),
     integer2=neps.IntegerParameter(lower=1, upper=1000, log=True),

--- a/neps_examples/convenience/logging_additional_info.py
+++ b/neps_examples/convenience/logging_additional_info.py
@@ -21,9 +21,9 @@ def run_pipeline(float1, float2, categorical, integer1, integer2):
 pipeline_space = dict(
     float1=neps.Float(lower=0, upper=1),
     float2=neps.Float(lower=-10, upper=10),
-    categorical=neps.CategoricalParameter(choices=[0, 1]),
-    integer1=neps.IntegerParameter(lower=0, upper=1),
-    integer2=neps.IntegerParameter(lower=1, upper=1000, log=True),
+    categorical=neps.Categorical(choices=[0, 1]),
+    integer1=neps.Integer(lower=0, upper=1),
+    integer2=neps.Integer(lower=1, upper=1000, log=True),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/convenience/neps_tblogger_tutorial.py
+++ b/neps_examples/convenience/neps_tblogger_tutorial.py
@@ -232,9 +232,9 @@ def training(
 
 def pipeline_space() -> dict:
     pipeline = dict(
-        lr=neps.FloatParameter(lower=1e-5, upper=1e-1, log=True),
+        lr=neps.Float(lower=1e-5, upper=1e-1, log=True),
         optim=neps.CategoricalParameter(choices=["Adam", "SGD"]),
-        weight_decay=neps.FloatParameter(lower=1e-4, upper=1e-1, log=True),
+        weight_decay=neps.Float(lower=1e-4, upper=1e-1, log=True),
     )
 
     return pipeline

--- a/neps_examples/convenience/neps_tblogger_tutorial.py
+++ b/neps_examples/convenience/neps_tblogger_tutorial.py
@@ -233,7 +233,7 @@ def training(
 def pipeline_space() -> dict:
     pipeline = dict(
         lr=neps.Float(lower=1e-5, upper=1e-1, log=True),
-        optim=neps.CategoricalParameter(choices=["Adam", "SGD"]),
+        optim=neps.Categorical(choices=["Adam", "SGD"]),
         weight_decay=neps.Float(lower=1e-4, upper=1e-1, log=True),
     )
 

--- a/neps_examples/convenience/neps_x_lightning.py
+++ b/neps_examples/convenience/neps_x_lightning.py
@@ -251,8 +251,8 @@ def search_space() -> dict:
     space = dict(
         data_dir=neps.ConstantParameter("./data"),
         batch_size=neps.ConstantParameter(64),
-        lr=neps.FloatParameter(lower=1e-5, upper=1e-2, log=True, default=1e-3),
-        weight_decay=neps.FloatParameter(
+        lr=neps.Float(lower=1e-5, upper=1e-2, log=True, default=1e-3),
+        weight_decay=neps.Float(
             lower=1e-5, upper=1e-3, log=True, default=5e-4
         ),
         optimizer=neps.CategoricalParameter(choices=["Adam", "SGD"], default="Adam"),

--- a/neps_examples/convenience/neps_x_lightning.py
+++ b/neps_examples/convenience/neps_x_lightning.py
@@ -249,14 +249,14 @@ class LitMNIST(L.LightningModule):
 def search_space() -> dict:
     # Define a dictionary to represent the hyperparameter search space
     space = dict(
-        data_dir=neps.ConstantParameter("./data"),
-        batch_size=neps.ConstantParameter(64),
+        data_dir=neps.Constant("./data"),
+        batch_size=neps.Constant(64),
         lr=neps.Float(lower=1e-5, upper=1e-2, log=True, default=1e-3),
         weight_decay=neps.Float(
             lower=1e-5, upper=1e-3, log=True, default=5e-4
         ),
-        optimizer=neps.CategoricalParameter(choices=["Adam", "SGD"], default="Adam"),
-        epochs=neps.IntegerParameter(lower=1, upper=9, log=False, is_fidelity=True),
+        optimizer=neps.Categorical(choices=["Adam", "SGD"], default="Adam"),
+        epochs=neps.Integer(lower=1, upper=9, log=False, is_fidelity=True),
     )
     return space
 

--- a/neps_examples/convenience/running_on_slurm_scripts.py
+++ b/neps_examples/convenience/running_on_slurm_scripts.py
@@ -52,7 +52,7 @@ echo -10 > {pipeline_directory}/validation_error_from_slurm_job.txt
 
 
 pipeline_space = dict(
-    optimizer=neps.CategoricalParameter(choices=["sgd", "adam"]),
+    optimizer=neps.Categorical(choices=["sgd", "adam"]),
     learning_rate=neps.Float(lower=10e-7, upper=10e-3, log=True),
 )
 

--- a/neps_examples/convenience/running_on_slurm_scripts.py
+++ b/neps_examples/convenience/running_on_slurm_scripts.py
@@ -53,7 +53,7 @@ echo -10 > {pipeline_directory}/validation_error_from_slurm_job.txt
 
 pipeline_space = dict(
     optimizer=neps.CategoricalParameter(choices=["sgd", "adam"]),
-    learning_rate=neps.FloatParameter(lower=10e-7, upper=10e-3, log=True),
+    learning_rate=neps.Float(lower=10e-7, upper=10e-3, log=True),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/convenience/working_directory_per_pipeline.py
+++ b/neps_examples/convenience/working_directory_per_pipeline.py
@@ -18,7 +18,7 @@ def run_pipeline(pipeline_directory: Path, float1, categorical, integer1):
 
 
 pipeline_space = dict(
-    float1=neps.FloatParameter(lower=0, upper=1),
+    float1=neps.Float(lower=0, upper=1),
     categorical=neps.CategoricalParameter(choices=[0, 1]),
     integer1=neps.IntegerParameter(lower=0, upper=1),
 )

--- a/neps_examples/convenience/working_directory_per_pipeline.py
+++ b/neps_examples/convenience/working_directory_per_pipeline.py
@@ -19,8 +19,8 @@ def run_pipeline(pipeline_directory: Path, float1, categorical, integer1):
 
 pipeline_space = dict(
     float1=neps.Float(lower=0, upper=1),
-    categorical=neps.CategoricalParameter(choices=[0, 1]),
-    integer1=neps.IntegerParameter(lower=0, upper=1),
+    categorical=neps.Categorical(choices=[0, 1]),
+    integer1=neps.Integer(lower=0, upper=1),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/efficiency/expert_priors_for_hyperparameters.py
+++ b/neps_examples/efficiency/expert_priors_for_hyperparameters.py
@@ -26,10 +26,10 @@ pipeline_space = dict(
     some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
-    some_integer=neps.IntegerParameter(
+    some_integer=neps.Integer(
         lower=0, upper=50, default=35, default_confidence="low"
     ),
-    some_cat=neps.CategoricalParameter(
+    some_cat=neps.Categorical(
         choices=["a", "b", "c"], default="a", default_confidence="high"
     ),
 )

--- a/neps_examples/efficiency/expert_priors_for_hyperparameters.py
+++ b/neps_examples/efficiency/expert_priors_for_hyperparameters.py
@@ -23,7 +23,7 @@ def run_pipeline(some_float, some_integer, some_cat):
 # neps uses the default values and a confidence in this default value to construct a prior
 # that speeds up the search
 pipeline_space = dict(
-    some_float=neps.FloatParameter(
+    some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
     some_integer=neps.IntegerParameter(

--- a/neps_examples/efficiency/multi_fidelity.py
+++ b/neps_examples/efficiency/multi_fidelity.py
@@ -73,7 +73,7 @@ def run_pipeline(pipeline_directory, previous_pipeline_directory, learning_rate,
 
 
 pipeline_space = dict(
-    learning_rate=neps.FloatParameter(lower=1e-4, upper=1e0, log=True),
+    learning_rate=neps.Float(lower=1e-4, upper=1e0, log=True),
     epoch=neps.IntegerParameter(lower=1, upper=10, is_fidelity=True),
 )
 

--- a/neps_examples/efficiency/multi_fidelity.py
+++ b/neps_examples/efficiency/multi_fidelity.py
@@ -74,7 +74,7 @@ def run_pipeline(pipeline_directory, previous_pipeline_directory, learning_rate,
 
 pipeline_space = dict(
     learning_rate=neps.Float(lower=1e-4, upper=1e0, log=True),
-    epoch=neps.IntegerParameter(lower=1, upper=10, is_fidelity=True),
+    epoch=neps.Integer(lower=1, upper=10, is_fidelity=True),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/efficiency/multi_fidelity_and_expert_priors.py
+++ b/neps_examples/efficiency/multi_fidelity_and_expert_priors.py
@@ -17,10 +17,10 @@ pipeline_space = dict(
     float2=neps.Float(
         lower=-10, upper=10, default=0, default_confidence="medium"
     ),
-    integer1=neps.IntegerParameter(
+    integer1=neps.Integer(
         lower=0, upper=50, default=35, default_confidence="low"
     ),
-    fidelity=neps.IntegerParameter(lower=1, upper=10, is_fidelity=True),
+    fidelity=neps.Integer(lower=1, upper=10, is_fidelity=True),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/efficiency/multi_fidelity_and_expert_priors.py
+++ b/neps_examples/efficiency/multi_fidelity_and_expert_priors.py
@@ -11,10 +11,10 @@ def run_pipeline(float1, float2, integer1, fidelity):
 
 
 pipeline_space = dict(
-    float1=neps.FloatParameter(
+    float1=neps.Float(
         lower=1, upper=1000, log=False, default=600, default_confidence="medium"
     ),
-    float2=neps.FloatParameter(
+    float2=neps.Float(
         lower=-10, upper=10, default=0, default_confidence="medium"
     ),
     integer1=neps.IntegerParameter(

--- a/neps_examples/experimental/cost_aware.py
+++ b/neps_examples/experimental/cost_aware.py
@@ -23,9 +23,9 @@ pipeline_space = dict(
     float2=neps.Float(
         lower=0, upper=10, log=False, default=10, default_confidence="medium"
     ),
-    categorical=neps.CategoricalParameter(choices=[0, 1]),
-    integer1=neps.IntegerParameter(lower=0, upper=1, log=False),
-    integer2=neps.IntegerParameter(lower=0, upper=1, log=False),
+    categorical=neps.Categorical(choices=[0, 1]),
+    integer1=neps.Integer(lower=0, upper=1, log=False),
+    integer2=neps.Integer(lower=0, upper=1, log=False),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/experimental/cost_aware.py
+++ b/neps_examples/experimental/cost_aware.py
@@ -19,8 +19,8 @@ def run_pipeline(
 
 
 pipeline_space = dict(
-    float1=neps.FloatParameter(lower=0, upper=1, log=False),
-    float2=neps.FloatParameter(
+    float1=neps.Float(lower=0, upper=1, log=False),
+    float2=neps.Float(
         lower=0, upper=10, log=False, default=10, default_confidence="medium"
     ),
     categorical=neps.CategoricalParameter(choices=[0, 1]),

--- a/neps_examples/experimental/expert_priors_for_architecture_and_hyperparameters.py
+++ b/neps_examples/experimental/expert_priors_for_architecture_and_hyperparameters.py
@@ -116,10 +116,10 @@ pipeline_space = dict(
     some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
-    some_integer=neps.IntegerParameter(
+    some_integer=neps.Integer(
         lower=0, upper=50, default=35, default_confidence="low"
     ),
-    some_cat=neps.CategoricalParameter(
+    some_cat=neps.Categorical(
         choices=["a", "b", "c"], default="a", default_confidence="high"
     ),
 )

--- a/neps_examples/experimental/expert_priors_for_architecture_and_hyperparameters.py
+++ b/neps_examples/experimental/expert_priors_for_architecture_and_hyperparameters.py
@@ -113,7 +113,7 @@ pipeline_space = dict(
         name="pibo",
         prior=prior_distr,
     ),
-    some_float=neps.FloatParameter(
+    some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
     some_integer=neps.IntegerParameter(

--- a/neps_examples/experimental/fault_tolerance.py
+++ b/neps_examples/experimental/fault_tolerance.py
@@ -78,7 +78,7 @@ def run_pipeline(pipeline_directory, learning_rate):
 
 
 pipeline_space = dict(
-    learning_rate=neps.FloatParameter(lower=0, upper=1),
+    learning_rate=neps.Float(lower=0, upper=1),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/neps_examples/experimental/user_priors_from_arbitrary_densities.py
+++ b/neps_examples/experimental/user_priors_from_arbitrary_densities.py
@@ -11,7 +11,7 @@ def run_pipeline(some_float, some_integer, some_cat):
 # Current API
 # User prior is given as a default value and a confidence level specified in the parameter itself
 pipeline_space = dict(
-    some_float=neps.FloatParameter(
+    some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
     some_integer=neps.IntegerParameter(
@@ -37,7 +37,7 @@ neps.run(
 # 3) A dictionary of default values and confidence levels for each parameter. Then a gaussian prior is used.
 
 pipeline_space = dict(
-    some_float=neps.FloatParameter(lower=1, upper=1000, log=True),
+    some_float=neps.Float(lower=1, upper=1000, log=True),
     some_integer=neps.IntegerParameter(lower=0, upper=50),
     some_cat=neps.CategoricalParameter(choices=["a", "b", "c"])
 )
@@ -95,7 +95,7 @@ def prior_01(some_float, some_integer, some_cat):
         return np.exp(-(-some_float - some_integer + 1050))
 
 pipeline_space_01 = dict(
-    some_float=neps.FloatParameter(lower=1, upper=1000, log=True),
+    some_float=neps.Float(lower=1, upper=1000, log=True),
     some_integer=neps.IntegerParameter(lower=0, upper=50),
     some_cat=neps.CategoricalParameter(choices=["a", "b", "c"]),
     _prior=prior_01
@@ -103,7 +103,7 @@ pipeline_space_01 = dict(
 
 # 2) A dictionary of marginal densities for each parameter. Then the factorized density is used.
 pipeline_space_02 = dict(
-    some_float=neps.FloatParameter(
+    some_float=neps.Float(
         lower=1, upper=1000, log=True,
         prior_fun=lambda x: 1/400 if 800 < x < 1000 else 1/1600
     ),
@@ -118,7 +118,7 @@ pipeline_space_02 = dict(
 # 3) A dictionary of default values and confidence levels for each parameter. Then a gaussian prior is used.
 # Same as in the current API
 pipeline_space_03 = dict(
-    some_float=neps.FloatParameter(
+    some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
     some_integer=neps.IntegerParameter(
@@ -131,7 +131,7 @@ pipeline_space_03 = dict(
 
 # Combination of 2) and 3)
 pipeline_space_04 = dict(
-    some_float=neps.FloatParameter(
+    some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium",
     ),
     some_integer=neps.IntegerParameter(

--- a/neps_examples/experimental/user_priors_from_arbitrary_densities.py
+++ b/neps_examples/experimental/user_priors_from_arbitrary_densities.py
@@ -14,10 +14,10 @@ pipeline_space = dict(
     some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
-    some_integer=neps.IntegerParameter(
+    some_integer=neps.Integer(
         lower=0, upper=50, default=35, default_confidence="low"
     ),
-    some_cat=neps.CategoricalParameter(
+    some_cat=neps.Categorical(
         choices=["a", "b", "c"], default="a", default_confidence="high"
     )
 )
@@ -38,8 +38,8 @@ neps.run(
 
 pipeline_space = dict(
     some_float=neps.Float(lower=1, upper=1000, log=True),
-    some_integer=neps.IntegerParameter(lower=0, upper=50),
-    some_cat=neps.CategoricalParameter(choices=["a", "b", "c"])
+    some_integer=neps.Integer(lower=0, upper=50),
+    some_cat=neps.Categorical(choices=["a", "b", "c"])
 )
 
 # 1) A (non-factorized) density function that returns the likelihood of a given parameter configuration
@@ -96,8 +96,8 @@ def prior_01(some_float, some_integer, some_cat):
 
 pipeline_space_01 = dict(
     some_float=neps.Float(lower=1, upper=1000, log=True),
-    some_integer=neps.IntegerParameter(lower=0, upper=50),
-    some_cat=neps.CategoricalParameter(choices=["a", "b", "c"]),
+    some_integer=neps.Integer(lower=0, upper=50),
+    some_cat=neps.Categorical(choices=["a", "b", "c"]),
     _prior=prior_01
 )
 
@@ -107,12 +107,12 @@ pipeline_space_02 = dict(
         lower=1, upper=1000, log=True,
         prior_fun=lambda x: 1/400 if 800 < x < 1000 else 1/1600
     ),
-    some_integer=neps.IntegerParameter(lower=0, upper=50,
-        prior_fun=lambda k: 30**k/np.math.factorial(k) * np.exp(-k)
-),
-    some_cat=neps.CategoricalParameter(choices=["a", "b", "c"],
-        prior_fun=lambda x: 1/2*(x=="b") + 1/3*(x=="c") + 1/6*(x=="a")
-    )
+    some_integer=neps.Integer(lower=0, upper=50,
+                              prior_fun=lambda k: 30**k/np.math.factorial(k) * np.exp(-k)
+                              ),
+    some_cat=neps.Categorical(choices=["a", "b", "c"],
+                              prior_fun=lambda x: 1/2*(x=="b") + 1/3*(x=="c") + 1/6*(x=="a")
+                              )
 )
 
 # 3) A dictionary of default values and confidence levels for each parameter. Then a gaussian prior is used.
@@ -121,10 +121,10 @@ pipeline_space_03 = dict(
     some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium"
     ),
-    some_integer=neps.IntegerParameter(
+    some_integer=neps.Integer(
         lower=0, upper=50, default=35, default_confidence="low"
     ),
-    some_cat=neps.CategoricalParameter(
+    some_cat=neps.Categorical(
         choices=["a", "b", "c"], default="a", default_confidence="high"
     )
 )
@@ -134,11 +134,11 @@ pipeline_space_04 = dict(
     some_float=neps.Float(
         lower=1, upper=1000, log=True, default=900, default_confidence="medium",
     ),
-    some_integer=neps.IntegerParameter(
+    some_integer=neps.Integer(
         lower=0, upper=50,
         prior_fun=lambda k: 30**k/np.math.factorial(k) * np.exp(-k)
     ),
-    some_cat=neps.CategoricalParameter(
+    some_cat=neps.Categorical(
         choices=["a", "b", "c"], default="a", default_confidence="high")
 )
 

--- a/neps_examples/template/basic_template.py
+++ b/neps_examples/template/basic_template.py
@@ -36,7 +36,7 @@ def pipeline_space() -> dict:
     # Create the search space based on NEPS parameters and return the dictionary.
     # Example:
     space = dict(
-        lr=neps.FloatParameter(
+        lr=neps.Float(
             lower=1e-5,
             upper=1e-2,
             log=True,      # If True, the search space is sampled in log space

--- a/neps_examples/template/lightning_template.py
+++ b/neps_examples/template/lightning_template.py
@@ -54,8 +54,8 @@ def pipeline_space() -> dict:
             log=True,  # If True, the search space is sampled in log space
             default=1e-3,  # a non-None value here acts as the mode of the prior distribution
         ),
-        optimizer=neps.CategoricalParameter(choices=["Adam", "SGD"], default="Adam"),
-        epochs=neps.IntegerParameter(
+        optimizer=neps.Categorical(choices=["Adam", "SGD"], default="Adam"),
+        epochs=neps.Integer(
             lower=1,
             upper=9,
             is_fidelity=True,  # IMPORTANT to set this to True for the fidelity parameter

--- a/neps_examples/template/lightning_template.py
+++ b/neps_examples/template/lightning_template.py
@@ -48,7 +48,7 @@ def pipeline_space() -> dict:
     # Create the search space based on NEPS parameters and return the dictionary.
     # IMPORTANT:
     space = dict(
-        lr=neps.FloatParameter(
+        lr=neps.Float(
             lower=1e-5,
             upper=1e-2,
             log=True,  # If True, the search space is sampled in log space

--- a/neps_examples/template/priorband_template.py
+++ b/neps_examples/template/priorband_template.py
@@ -54,7 +54,7 @@ def pipeline_space() -> dict:
             log=True,
             default=1e-3,
         ),
-        epoch=neps.IntegerParameter(
+        epoch=neps.Integer(
             lower=1,
             upper=10,
             is_fidelity=True,  # IMPORTANT to set this to True for the fidelity parameter

--- a/neps_examples/template/priorband_template.py
+++ b/neps_examples/template/priorband_template.py
@@ -42,13 +42,13 @@ def pipeline_space() -> dict:
     # Create the search space based on NEPS parameters and return the dictionary.
     # IMPORTANT:
     space = dict(
-        lr=neps.FloatParameter(
+        lr=neps.Float(
             lower=1e-5,
             upper=1e-2,
             log=True,  # If True, the search space is sampled in log space
             default=1e-3,  # a non-None value here acts as the mode of the prior distribution
         ),
-        wd=neps.FloatParameter(
+        wd=neps.Float(
             lower=0,
             upper=1e-1,
             log=True,

--- a/tests/regression_objectives.py
+++ b/tests/regression_objectives.py
@@ -280,7 +280,7 @@ class HartmannObjective(RegressionObjectiveBase):
             )
 
         self.pipeline_space: dict[str, Any] = {
-            f"X_{i}": neps.FloatParameter(lower=0.0, upper=1.0) for i in range(self.dim)
+            f"X_{i}": neps.Float(lower=0.0, upper=1.0) for i in range(self.dim)
         }
 
         if self.has_fidelity:

--- a/tests/regression_objectives.py
+++ b/tests/regression_objectives.py
@@ -122,7 +122,7 @@ class JAHSObjective(RegressionObjectiveBase):
         # For Regularized evolution sampler ignores fidelity hyperparameters
         # by sampling None for them
 
-        self.pipeline_space["epoch"] = neps.IntegerParameter(
+        self.pipeline_space["epoch"] = neps.Integer(
             lower=1, upper=200, is_fidelity=self.has_fidelity
         )
         self.run_pipeline = self.evaluation_func()
@@ -284,7 +284,7 @@ class HartmannObjective(RegressionObjectiveBase):
         }
 
         if self.has_fidelity:
-            self.pipeline_space["z"] = neps.IntegerParameter(
+            self.pipeline_space["z"] = neps.Integer(
                 lower=self.z_min, upper=self.z_max, is_fidelity=self.has_fidelity
             )
 

--- a/tests/test_neps_api/testing_scripts/baseoptimizer_neps.py
+++ b/tests/test_neps_api/testing_scripts/baseoptimizer_neps.py
@@ -7,12 +7,12 @@ from neps.search_spaces.search_space import SearchSpace
 
 pipeline_space_fidelity = dict(
     val1=neps.Float(lower=-10, upper=10),
-    val2=neps.IntegerParameter(lower=1, upper=5, is_fidelity=True),
+    val2=neps.Integer(lower=1, upper=5, is_fidelity=True),
 )
 
 pipeline_space = dict(
     val1=neps.Float(lower=-10, upper=10),
-    val2=neps.IntegerParameter(lower=1, upper=5),
+    val2=neps.Integer(lower=1, upper=5),
 )
 
 

--- a/tests/test_neps_api/testing_scripts/baseoptimizer_neps.py
+++ b/tests/test_neps_api/testing_scripts/baseoptimizer_neps.py
@@ -6,12 +6,12 @@ from neps.optimizers.multi_fidelity.hyperband import Hyperband
 from neps.search_spaces.search_space import SearchSpace
 
 pipeline_space_fidelity = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10),
+    val1=neps.Float(lower=-10, upper=10),
     val2=neps.IntegerParameter(lower=1, upper=5, is_fidelity=True),
 )
 
 pipeline_space = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10),
+    val1=neps.Float(lower=-10, upper=10),
     val2=neps.IntegerParameter(lower=1, upper=5),
 )
 

--- a/tests/test_neps_api/testing_scripts/default_neps.py
+++ b/tests/test_neps_api/testing_scripts/default_neps.py
@@ -7,22 +7,22 @@ from neps.optimizers.bayesian_optimization.models.gp_hierarchy import (
 )
 
 pipeline_space_fidelity_priors = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10, default=1),
+    val1=neps.Float(lower=-10, upper=10, default=1),
     val2=neps.IntegerParameter(lower=1, upper=5, is_fidelity=True),
 )
 
 pipeline_space_not_fidelity_priors = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10, default=1),
+    val1=neps.Float(lower=-10, upper=10, default=1),
     val2=neps.IntegerParameter(lower=1, upper=5, default=1),
 )
 
 pipeline_space_fidelity = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10),
+    val1=neps.Float(lower=-10, upper=10),
     val2=neps.IntegerParameter(lower=1, upper=5, is_fidelity=True),
 )
 
 pipeline_space_not_fidelity = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10),
+    val1=neps.Float(lower=-10, upper=10),
     val2=neps.IntegerParameter(lower=1, upper=5),
 )
 

--- a/tests/test_neps_api/testing_scripts/default_neps.py
+++ b/tests/test_neps_api/testing_scripts/default_neps.py
@@ -8,22 +8,22 @@ from neps.optimizers.bayesian_optimization.models.gp_hierarchy import (
 
 pipeline_space_fidelity_priors = dict(
     val1=neps.Float(lower=-10, upper=10, default=1),
-    val2=neps.IntegerParameter(lower=1, upper=5, is_fidelity=True),
+    val2=neps.Integer(lower=1, upper=5, is_fidelity=True),
 )
 
 pipeline_space_not_fidelity_priors = dict(
     val1=neps.Float(lower=-10, upper=10, default=1),
-    val2=neps.IntegerParameter(lower=1, upper=5, default=1),
+    val2=neps.Integer(lower=1, upper=5, default=1),
 )
 
 pipeline_space_fidelity = dict(
     val1=neps.Float(lower=-10, upper=10),
-    val2=neps.IntegerParameter(lower=1, upper=5, is_fidelity=True),
+    val2=neps.Integer(lower=1, upper=5, is_fidelity=True),
 )
 
 pipeline_space_not_fidelity = dict(
     val1=neps.Float(lower=-10, upper=10),
-    val2=neps.IntegerParameter(lower=1, upper=5),
+    val2=neps.Integer(lower=1, upper=5),
 )
 
 

--- a/tests/test_neps_api/testing_scripts/user_yaml_neps.py
+++ b/tests/test_neps_api/testing_scripts/user_yaml_neps.py
@@ -5,7 +5,7 @@ import neps
 
 pipeline_space = dict(
     val1=neps.Float(lower=-10, upper=10),
-    val2=neps.IntegerParameter(lower=1, upper=5),
+    val2=neps.Integer(lower=1, upper=5),
 )
 
 

--- a/tests/test_neps_api/testing_scripts/user_yaml_neps.py
+++ b/tests/test_neps_api/testing_scripts/user_yaml_neps.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import neps
 
 pipeline_space = dict(
-    val1=neps.FloatParameter(lower=-10, upper=10),
+    val1=neps.Float(lower=-10, upper=10),
     val2=neps.IntegerParameter(lower=1, upper=5),
 )
 

--- a/tests/test_runtime/test_default_report_values.py
+++ b/tests/test_runtime/test_default_report_values.py
@@ -8,7 +8,7 @@ from neps.state.filebased import create_or_load_filebased_neps_state
 from neps.state.neps_state import NePSState
 from neps.state.optimizer import OptimizationState, OptimizerInfo
 from neps.state.settings import DefaultReportValues, OnErrorPossibilities, WorkerSettings
-from neps.search_spaces import FloatParameter
+from neps.search_spaces import Float
 from neps.state.trial import Trial
 
 
@@ -24,7 +24,7 @@ def neps_state(tmp_path: Path) -> NePSState[Path]:
 def test_default_values_on_error(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(
@@ -75,7 +75,7 @@ def test_default_values_on_error(
 def test_default_values_on_not_specified(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(
@@ -124,7 +124,7 @@ def test_default_values_on_not_specified(
 def test_default_value_loss_curve_take_loss_value(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(learning_curve_if_not_provided="loss"),

--- a/tests/test_runtime/test_error_handling_strategies.py
+++ b/tests/test_runtime/test_error_handling_strategies.py
@@ -13,7 +13,7 @@ from neps.state.filebased import create_or_load_filebased_neps_state
 from neps.state.neps_state import NePSState
 from neps.state.optimizer import OptimizationState, OptimizerInfo
 from neps.state.settings import DefaultReportValues, OnErrorPossibilities, WorkerSettings
-from neps.search_spaces import FloatParameter
+from neps.search_spaces import Float
 from neps.state.trial import Trial
 
 
@@ -34,7 +34,7 @@ def test_worker_raises_when_error_in_self(
     neps_state: NePSState,
     on_error: OnErrorPossibilities,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=on_error,  # <- Highlight
         default_report_values=DefaultReportValues(),
@@ -73,7 +73,7 @@ def test_worker_raises_when_error_in_self(
 
 
 def test_worker_raises_when_error_in_other_worker(neps_state: NePSState) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.RAISE_ANY_ERROR,  # <- Highlight
         default_report_values=DefaultReportValues(),
@@ -133,7 +133,7 @@ def test_worker_does_not_raise_when_error_in_other_worker(
     neps_state: NePSState,
     on_error: OnErrorPossibilities,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.RAISE_WORKER_ERROR,  # <- Highlight
         default_report_values=DefaultReportValues(),

--- a/tests/test_runtime/test_stopping_criterion.py
+++ b/tests/test_runtime/test_stopping_criterion.py
@@ -9,7 +9,7 @@ from neps.state.filebased import create_or_load_filebased_neps_state
 from neps.state.neps_state import NePSState
 from neps.state.optimizer import OptimizationState, OptimizerInfo
 from neps.state.settings import DefaultReportValues, OnErrorPossibilities, WorkerSettings
-from neps.search_spaces import FloatParameter
+from neps.search_spaces import Float
 from neps.state.trial import Trial
 
 
@@ -25,7 +25,7 @@ def neps_state(tmp_path: Path) -> NePSState[Path]:
 def test_max_evaluations_total_stopping_criterion(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -78,7 +78,7 @@ def test_max_evaluations_total_stopping_criterion(
 def test_worker_evaluations_total_stopping_criterion(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -140,7 +140,7 @@ def test_worker_evaluations_total_stopping_criterion(
 def test_include_in_progress_evaluations_towards_maximum_with_work_eval_count(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -196,7 +196,7 @@ def test_include_in_progress_evaluations_towards_maximum_with_work_eval_count(
 def test_max_cost_total(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -247,7 +247,7 @@ def test_max_cost_total(
 def test_worker_cost_total(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -306,7 +306,7 @@ def test_worker_cost_total(
 def test_worker_wallclock_time(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -364,7 +364,7 @@ def test_worker_wallclock_time(
 def test_max_worker_evaluation_time(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
@@ -423,7 +423,7 @@ def test_max_worker_evaluation_time(
 def test_max_evaluation_time_global(
     neps_state: NePSState,
 ) -> None:
-    optimizer = RandomSearch(pipeline_space=SearchSpace(a=FloatParameter(0, 1)))
+    optimizer = RandomSearch(pipeline_space=SearchSpace(a=Float(0, 1)))
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),

--- a/tests/test_state/test_neps_state.py
+++ b/tests/test_state/test_neps_state.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 from neps.optimizers.base_optimizer import BaseOptimizer
 from neps.search_spaces.hyperparameters import (
-    FloatParameter,
+    Float,
     IntegerParameter,
     ConstantParameter,
     CategoricalParameter,
@@ -29,7 +29,7 @@ from neps.utils.common import MissingDependencyError
 @case
 def case_search_space_no_fid() -> SearchSpace:
     return SearchSpace(
-        a=FloatParameter(0, 1),
+        a=Float(0, 1),
         b=CategoricalParameter(["a", "b", "c"]),
         c=ConstantParameter("a"),
         d=IntegerParameter(0, 10),
@@ -39,7 +39,7 @@ def case_search_space_no_fid() -> SearchSpace:
 @case
 def case_search_space_with_fid() -> SearchSpace:
     return SearchSpace(
-        a=FloatParameter(0, 1),
+        a=Float(0, 1),
         b=CategoricalParameter(["a", "b", "c"]),
         c=ConstantParameter("a"),
         d=IntegerParameter(0, 10),
@@ -50,7 +50,7 @@ def case_search_space_with_fid() -> SearchSpace:
 @case
 def case_search_space_no_fid_with_prior() -> SearchSpace:
     return SearchSpace(
-        a=FloatParameter(0, 1, default=0.5),
+        a=Float(0, 1, default=0.5),
         b=CategoricalParameter(["a", "b", "c"], default="a"),
         c=ConstantParameter("a"),
         d=IntegerParameter(0, 10, default=5),
@@ -60,7 +60,7 @@ def case_search_space_no_fid_with_prior() -> SearchSpace:
 @case
 def case_search_space_fid_with_prior() -> SearchSpace:
     return SearchSpace(
-        a=FloatParameter(0, 1, default=0.5),
+        a=Float(0, 1, default=0.5),
         b=CategoricalParameter(["a", "b", "c"], default="a"),
         c=ConstantParameter("a"),
         d=IntegerParameter(0, 10, default=5),

--- a/tests/test_state/test_neps_state.py
+++ b/tests/test_state/test_neps_state.py
@@ -10,9 +10,9 @@ import pytest
 from neps.optimizers.base_optimizer import BaseOptimizer
 from neps.search_spaces.hyperparameters import (
     Float,
-    IntegerParameter,
-    ConstantParameter,
-    CategoricalParameter,
+    Integer,
+    Constant,
+    Categorical,
 )
 from neps.search_spaces.search_space import SearchSpace
 from neps.state.filebased import (
@@ -30,9 +30,9 @@ from neps.utils.common import MissingDependencyError
 def case_search_space_no_fid() -> SearchSpace:
     return SearchSpace(
         a=Float(0, 1),
-        b=CategoricalParameter(["a", "b", "c"]),
-        c=ConstantParameter("a"),
-        d=IntegerParameter(0, 10),
+        b=Categorical(["a", "b", "c"]),
+        c=Constant("a"),
+        d=Integer(0, 10),
     )
 
 
@@ -40,10 +40,10 @@ def case_search_space_no_fid() -> SearchSpace:
 def case_search_space_with_fid() -> SearchSpace:
     return SearchSpace(
         a=Float(0, 1),
-        b=CategoricalParameter(["a", "b", "c"]),
-        c=ConstantParameter("a"),
-        d=IntegerParameter(0, 10),
-        e=IntegerParameter(1, 10, is_fidelity=True),
+        b=Categorical(["a", "b", "c"]),
+        c=Constant("a"),
+        d=Integer(0, 10),
+        e=Integer(1, 10, is_fidelity=True),
     )
 
 
@@ -51,9 +51,9 @@ def case_search_space_with_fid() -> SearchSpace:
 def case_search_space_no_fid_with_prior() -> SearchSpace:
     return SearchSpace(
         a=Float(0, 1, default=0.5),
-        b=CategoricalParameter(["a", "b", "c"], default="a"),
-        c=ConstantParameter("a"),
-        d=IntegerParameter(0, 10, default=5),
+        b=Categorical(["a", "b", "c"], default="a"),
+        c=Constant("a"),
+        d=Integer(0, 10, default=5),
     )
 
 
@@ -61,10 +61,10 @@ def case_search_space_no_fid_with_prior() -> SearchSpace:
 def case_search_space_fid_with_prior() -> SearchSpace:
     return SearchSpace(
         a=Float(0, 1, default=0.5),
-        b=CategoricalParameter(["a", "b", "c"], default="a"),
-        c=ConstantParameter("a"),
-        d=IntegerParameter(0, 10, default=5),
-        e=IntegerParameter(1, 10, is_fidelity=True),
+        b=Categorical(["a", "b", "c"], default="a"),
+        c=Constant("a"),
+        d=Integer(0, 10, default=5),
+        e=Integer(1, 10, is_fidelity=True),
     )
 
 

--- a/tests/test_yaml_run_args/test_declarative_usage_docs/pipeline_space.py
+++ b/tests/test_yaml_run_args/test_declarative_usage_docs/pipeline_space.py
@@ -1,7 +1,7 @@
 import neps
 
 pipeline_space = dict(
-    learning_rate=neps.FloatParameter(lower=1e-5, upper=1e-1, log=True),
+    learning_rate=neps.Float(lower=1e-5, upper=1e-1, log=True),
     epochs=neps.IntegerParameter(lower=5, upper=20, is_fidelity=True),
     optimizer=neps.CategoricalParameter(choices=["adam", "sgd", "adamw"]),
     batch_size=neps.ConstantParameter(value=64)

--- a/tests/test_yaml_run_args/test_declarative_usage_docs/pipeline_space.py
+++ b/tests/test_yaml_run_args/test_declarative_usage_docs/pipeline_space.py
@@ -2,7 +2,7 @@ import neps
 
 pipeline_space = dict(
     learning_rate=neps.Float(lower=1e-5, upper=1e-1, log=True),
-    epochs=neps.IntegerParameter(lower=5, upper=20, is_fidelity=True),
-    optimizer=neps.CategoricalParameter(choices=["adam", "sgd", "adamw"]),
-    batch_size=neps.ConstantParameter(value=64)
+    epochs=neps.Integer(lower=5, upper=20, is_fidelity=True),
+    optimizer=neps.Categorical(choices=["adam", "sgd", "adamw"]),
+    batch_size=neps.Constant(value=64)
 )

--- a/tests/test_yaml_run_args/test_run_args_by_neps_run/neps_run.py
+++ b/tests/test_yaml_run_args/test_run_args_by_neps_run/neps_run.py
@@ -16,9 +16,9 @@ def run_pipeline(learning_rate, epochs, optimizer, batch_size):
 # For testing the functionality of loading a dictionary from a YAML configuration.
 pipeline_space = dict(
     learning_rate=neps.Float(lower=1e-6, upper=1e-1, log=False),
-    epochs=neps.IntegerParameter(lower=1, upper=3, is_fidelity=False),
-    optimizer=neps.CategoricalParameter(choices=["a", "b", "c"]),
-    batch_size=neps.ConstantParameter(64),
+    epochs=neps.Integer(lower=1, upper=3, is_fidelity=False),
+    optimizer=neps.Categorical(choices=["a", "b", "c"]),
+    batch_size=neps.Constant(64),
 )
 
 if __name__ == "__main__":

--- a/tests/test_yaml_run_args/test_run_args_by_neps_run/neps_run.py
+++ b/tests/test_yaml_run_args/test_run_args_by_neps_run/neps_run.py
@@ -15,7 +15,7 @@ def run_pipeline(learning_rate, epochs, optimizer, batch_size):
 
 # For testing the functionality of loading a dictionary from a YAML configuration.
 pipeline_space = dict(
-    learning_rate=neps.FloatParameter(lower=1e-6, upper=1e-1, log=False),
+    learning_rate=neps.Float(lower=1e-6, upper=1e-1, log=False),
     epochs=neps.IntegerParameter(lower=1, upper=3, is_fidelity=False),
     optimizer=neps.CategoricalParameter(choices=["a", "b", "c"]),
     batch_size=neps.ConstantParameter(64),

--- a/tests/test_yaml_run_args/test_yaml_run_args.py
+++ b/tests/test_yaml_run_args/test_yaml_run_args.py
@@ -5,7 +5,7 @@ from neps.optimizers.bayesian_optimization.optimizer import BayesianOptimization
 from typing import Union, Callable, Dict, List, Type
 
 BASE_PATH = "tests/test_yaml_run_args/"
-pipeline_space = dict(lr=neps.FloatParameter(lower=1e-3, upper=0.1),
+pipeline_space = dict(lr=neps.Float(lower=1e-3, upper=0.1),
                       optimizer=neps.CategoricalParameter(choices=["adam", "sgd",
                                                                    "adamw"]),
                       epochs=neps.IntegerParameter(lower=1, upper=10),

--- a/tests/test_yaml_run_args/test_yaml_run_args.py
+++ b/tests/test_yaml_run_args/test_yaml_run_args.py
@@ -6,10 +6,10 @@ from typing import Union, Callable, Dict, List, Type
 
 BASE_PATH = "tests/test_yaml_run_args/"
 pipeline_space = dict(lr=neps.Float(lower=1e-3, upper=0.1),
-                      optimizer=neps.CategoricalParameter(choices=["adam", "sgd",
+                      optimizer=neps.Categorical(choices=["adam", "sgd",
                                                                    "adamw"]),
-                      epochs=neps.IntegerParameter(lower=1, upper=10),
-                      batch_size=neps.ConstantParameter(value=64))
+                      epochs=neps.Integer(lower=1, upper=10),
+                      batch_size=neps.Constant(value=64))
 
 
 def run_pipeline():

--- a/tests/test_yaml_search_space/test_search_space.py
+++ b/tests/test_yaml_search_space/test_search_space.py
@@ -6,7 +6,7 @@ from neps.search_spaces.search_space import (
     pipeline_space_from_yaml,
 )
 
-from neps import CategoricalParameter, ConstantParameter, Float, IntegerParameter
+from neps import Categorical, Constant, Float, Integer
 
 BASE_PATH = "tests/test_yaml_search_space/"
 
@@ -19,17 +19,17 @@ def test_correct_yaml_files():
         assert isinstance(pipeline_space, dict)
         float1 = Float(0.00001, 0.1, log=True, is_fidelity=False)
         assert float1.__eq__(pipeline_space["param_float1"]) is True
-        int1 = IntegerParameter(-3, 30, log=False, is_fidelity=True)
+        int1 = Integer(-3, 30, log=False, is_fidelity=True)
         assert int1.__eq__(pipeline_space["param_int1"]) is True
-        int2 = IntegerParameter(100, 30000, log=True, is_fidelity=False)
+        int2 = Integer(100, 30000, log=True, is_fidelity=False)
         assert int2.__eq__(pipeline_space["param_int2"]) is True
         float2 = Float(3.3e-5, 0.15, log=False)
         assert float2.__eq__(pipeline_space["param_float2"]) is True
-        cat1 = CategoricalParameter([2, "sgd", 10e-3])
+        cat1 = Categorical([2, "sgd", 10e-3])
         assert cat1.__eq__(pipeline_space["param_cat"]) is True
-        const1 = ConstantParameter(0.5)
+        const1 = Constant(0.5)
         assert const1.__eq__(pipeline_space["param_const1"]) is True
-        const2 = ConstantParameter(1e3)
+        const2 = Constant(1e3)
         assert const2.__eq__(pipeline_space["param_const2"]) is True
 
     test_correct_yaml_file(BASE_PATH + "correct_config.yaml")
@@ -45,11 +45,11 @@ def test_correct_including_priors_yaml_file():
     assert isinstance(pipeline_space, dict)
     float1 = Float(0.00001, 0.1, log=True, is_fidelity=False, default=3.3e-2, default_confidence="high")
     assert float1.__eq__(pipeline_space["learning_rate"]) is True
-    int1 = IntegerParameter(3, 30, log=False, is_fidelity=True)
+    int1 = Integer(3, 30, log=False, is_fidelity=True)
     assert int1.__eq__(pipeline_space["num_epochs"]) is True
-    cat1 = CategoricalParameter(["adam", 90e-3, "rmsprop"], default=90e-3, default_confidence="medium")
+    cat1 = Categorical(["adam", 90e-3, "rmsprop"], default=90e-3, default_confidence="medium")
     assert cat1.__eq__(pipeline_space["optimizer"]) is True
-    const1 = ConstantParameter(1e3)
+    const1 = Constant(1e3)
     assert const1.__eq__(pipeline_space["dropout_rate"]) is True
 
 
@@ -139,7 +139,7 @@ def test_float_is_fidelity_not_boolean():
 @pytest.mark.neps_api
 def test_categorical_default_value_not_in_choices():
     """Test if a ValueError is raised when the default value is not in the choices
-    for a CategoricalParameter."""
+    for a Categorical."""
     with pytest.raises(SearchSpaceFromYamlFileError) as excinfo:
         pipeline_space_from_yaml(BASE_PATH + "default_value_not_in_choices_config.yaml")
     assert excinfo.value.exception_type == "ValueError"

--- a/tests/test_yaml_search_space/test_search_space.py
+++ b/tests/test_yaml_search_space/test_search_space.py
@@ -6,7 +6,7 @@ from neps.search_spaces.search_space import (
     pipeline_space_from_yaml,
 )
 
-from neps import CategoricalParameter, ConstantParameter, FloatParameter, IntegerParameter
+from neps import CategoricalParameter, ConstantParameter, Float, IntegerParameter
 
 BASE_PATH = "tests/test_yaml_search_space/"
 
@@ -17,13 +17,13 @@ def test_correct_yaml_files():
         """Test the function with a correctly formatted YAML file."""
         pipeline_space = pipeline_space_from_yaml(path)
         assert isinstance(pipeline_space, dict)
-        float1 = FloatParameter(0.00001, 0.1, log=True, is_fidelity=False)
+        float1 = Float(0.00001, 0.1, log=True, is_fidelity=False)
         assert float1.__eq__(pipeline_space["param_float1"]) is True
         int1 = IntegerParameter(-3, 30, log=False, is_fidelity=True)
         assert int1.__eq__(pipeline_space["param_int1"]) is True
         int2 = IntegerParameter(100, 30000, log=True, is_fidelity=False)
         assert int2.__eq__(pipeline_space["param_int2"]) is True
-        float2 = FloatParameter(3.3e-5, 0.15, log=False)
+        float2 = Float(3.3e-5, 0.15, log=False)
         assert float2.__eq__(pipeline_space["param_float2"]) is True
         cat1 = CategoricalParameter([2, "sgd", 10e-3])
         assert cat1.__eq__(pipeline_space["param_cat"]) is True
@@ -43,7 +43,7 @@ def test_correct_including_priors_yaml_file():
         BASE_PATH + "correct_config_including_priors.yml"
     )
     assert isinstance(pipeline_space, dict)
-    float1 = FloatParameter(0.00001, 0.1, log=True, is_fidelity=False, default=3.3e-2, default_confidence="high")
+    float1 = Float(0.00001, 0.1, log=True, is_fidelity=False, default=3.3e-2, default_confidence="high")
     assert float1.__eq__(pipeline_space["learning_rate"]) is True
     int1 = IntegerParameter(3, 30, log=False, is_fidelity=True)
     assert int1.__eq__(pipeline_space["num_epochs"]) is True
@@ -127,7 +127,7 @@ def test_float_log_not_boolean():
 
 @pytest.mark.neps_api
 def test_float_is_fidelity_not_boolean():
-    """Test if an exception is raised when for FloatParameter the 'is_fidelity'
+    """Test if an exception is raised when for Float the 'is_fidelity'
     attribute is not a boolean."""
     with pytest.raises(SearchSpaceFromYamlFileError) as excinfo:
         pipeline_space_from_yaml(


### PR DESCRIPTION
This pull request introduces the update to `FloatParameter` class and replaces it with the new `Float` class. Additionally, a deprecated `FloatParameter` class is introduced to maintain backward compatibility.

Here are the most important changes:

### Replacement of `FloatParameter` with `Float`:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R77): Updated `pipeline_space` to use `neps.Float` instead of `neps.FloatParameter`.
* [`docs/getting_started.md`](diffhunk://#diff-7627439dcd69d95a42bb123ac4cfb7682f86da5d6aee037206d9857459906243L62-R62): Changed `hyperparameter_a` to use `neps.Float` instead of `neps.FloatParameter`.
* [`docs/reference/pipeline_space.md`](diffhunk://#diff-ea1e9113a166b4ed8b7fff97b934cf76bc008d9f3faba06f9af19083cdd674ceL16-R16): Replaced all instances of `FloatParameter` with `Float`.
* [`neps/api.py`](diffhunk://#diff-22ac9c48864785f0b2753eb6bd4b7b7f649b98e1de17500fe0d710e38e34f9a1L125-R125): Updated `pipeline_space` example to use `neps.Float` instead of `neps.FloatParameter`.
* [`neps/optimizers/bayesian_optimization/kernels/get_kernels.py`](diffhunk://#diff-cf8ff0ae23e7033d121e9d4d0e825c1d9d8f11b6a70589f805eaeae5a9559580L4-R4): Replaced `FloatParameter` with `Float` in kernel checks.
* [`neps/optimizers/bayesian_optimization/mf_tpe.py`](diffhunk://#diff-f12fde8cc8d3c398a470fe9f560a73da25ffd73a63b669d9010d61045c71cb16L16-R16): Updated all references from `FloatParameter` to `Float`.
* [`neps/optimizers/bayesian_optimization/optimizer.py`](diffhunk://#diff-2e182a2e6094af75f96ffb49aef4fd838e1ced89e6bb0b4125fbbd9726c08912L13-R13): Replaced `FloatParameter` with `Float` in confidence scores and priors.
* [`neps/optimizers/multi_fidelity/ifbo.py`](diffhunk://#diff-887b73b92130290e000a381f2e729113b36a7bcb8d0f9bba9ec12f62bdb3786aL11-R11): Changed `FloatParameter` to `Float` in budget value calculations.
* [`neps/optimizers/multi_fidelity/successive_halving.py`](diffhunk://#diff-39770aec194903d61b6ca35b8115e30d70cd94a60ecf9177e88f564ad74eb9bdL17-R17): Updated `FloatParameter` to `Float` in confidence scores and priors.
* [`neps/search_spaces/hyperparameters/float.py`](diffhunk://#diff-b0d6cb6c3edfa5949a90c43dd0b6a2c643b74a7090e7e6da099182b9b663064fL18-R33): Renamed `FloatParameter` class to `Float` and added a deprecated `FloatParameter` class.

### Updates to `__init__.py` files:

* [`neps/__init__.py`](diffhunk://#diff-78c83b01047d27d740a7bf1cc7fa052022d7fe8b199bd7cf95d36fa809192883R8): Added `Float` and removed the alias for `FloatParameter`.
* [`neps/search_spaces/__init__.py`](diffhunk://#diff-f632e2dab6cf5171fda69814af7c1c2d5f874847baa577650dfb113b931b2668R11): Included `Float` in the import statements and `__all__` list.
* [`neps/search_spaces/hyperparameters/__init__.py`](diffhunk://#diff-90add44639d65c426db915f548b3eae2e62929b6d9d363f6519ead339f52ab8bL3-R11): Added `Float` to the import statements and `__all__` list.

These changes ensure that the new `Float` class is used consistently across the codebase while maintaining backward compatibility with the deprecated `FloatParameter` class.