### PR TITLE
ci: enforcing conventional commit naming in PR titles

### DIFF
--- a/.github/workflows/pr-conventional-commit.yml
+++ b/.github/workflows/pr-conventional-commit.yml
@@ -1,0 +1,15 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/PRConventionalCommits@1.2.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'


### PR DESCRIPTION
adds a GH workflow that checks whether PR titles follow conv commit

Closes #159 