### PR TITLE
fix(ifbo): Transformation of categoricals and handling of unusual fidelity bounds

### DIFF
--- a/neps/optimizers/bayesian_optimization.py
+++ b/neps/optimizers/bayesian_optimization.py
@@ -89,7 +89,9 @@ class BayesianOptimization:
 
         n_to_sample = 1 if n is None else n
         n_sampled = len(trials)
-        config_ids = iter(str(i + 1) for i in range(n_sampled, n_sampled + n_to_sample))
+        config_ids = iter(
+            str(i + 1) for i in range(n_sampled, n_sampled + n_to_sample + 1)
+        )
 
         # If the amount of configs evaluated is less than the initial design
         # requirement, keep drawing from initial design

--- a/neps/runtime.py
+++ b/neps/runtime.py
@@ -464,30 +464,29 @@ class DefaultWorker(Generic[Loc]):
                     return this_workers_trial
                 except TrialAlreadyExistsError as e:
                     if e.trial_id in trials:
-                        logger.error(
-                            "The new sampled trial was given an id of '%s', yet this"
-                            " exists in the loaded in trials given to the optimizer. This"
-                            " indicates a bug with the optimizers allocation of ids.",
-                            e.trial_id,
-                        )
-                    else:
-                        _grace = DefaultWorker._GRACE
-                        _inc = FS_SYNC_GRACE_INC
-                        logger.warning(
-                            "The new sampled trial was given an id of '%s', which is not"
-                            " one that was loaded in by the optimizer. This is usually"
-                            " an indication that the file-system you are running on"
-                            " is not atmoic in synchoronizing file operations."
-                            " We have attempted to stabalize this but milage may vary."
-                            " We are incrementing a grace period for file-locks from"
-                            " '%s's to '%s's. You can control the initial"
-                            " grace with 'NEPS_FS_SYNC_GRACE_BASE' and the increment with"
-                            " 'NEPS_FS_SYNC_GRACE_INC'.",
-                            e.trial_id,
-                            _grace,
-                            _grace + _inc,
-                        )
-                        DefaultWorker._GRACE = _grace + FS_SYNC_GRACE_INC
+                        raise RuntimeError(
+                            f"The new sampled trial was given an id of {e.trial_id}, yet"
+                            " this exists in the loaded in trials given to the optimizer."
+                            " This is a bug with the optimizers allocation of ids."
+                        ) from e
+
+                    _grace = DefaultWorker._GRACE
+                    _inc = FS_SYNC_GRACE_INC
+                    logger.warning(
+                        "The new sampled trial was given an id of '%s', which is not"
+                        " one that was loaded in by the optimizer. This is usually"
+                        " an indication that the file-system you are running on"
+                        " is not atmoic in synchoronizing file operations."
+                        " We have attempted to stabalize this but milage may vary."
+                        " We are incrementing a grace period for file-locks from"
+                        " '%s's to '%s's. You can control the initial"
+                        " grace with 'NEPS_FS_SYNC_GRACE_BASE' and the increment with"
+                        " 'NEPS_FS_SYNC_GRACE_INC'.",
+                        e.trial_id,
+                        _grace,
+                        _grace + _inc,
+                    )
+                    DefaultWorker._GRACE = _grace + FS_SYNC_GRACE_INC
                     raise e
 
     # Forgive me lord, for I have sinned, this function is atrocious but complicated

--- a/neps/space/parameters.py
+++ b/neps/space/parameters.py
@@ -75,6 +75,13 @@ class Float:
         self.lower = float(self.lower)
         self.upper = float(self.upper)
 
+        if self.is_fidelity and (self.lower < 0 or self.upper < 0):
+            raise ValueError(
+                f"Float parameter: fidelity bounds error. Expected fidelity"
+                f" bounds to be >= 0, but got lower={self.lower}, "
+                f" upper={self.upper}."
+            )
+
         if np.isnan(self.lower):
             raise ValueError("Can not have lower bound that is nan")
 
@@ -148,6 +155,13 @@ class Integer:
 
         self.lower = lower_int
         self.upper = upper_int
+
+        if self.is_fidelity and (self.lower < 0 or self.upper < 0):
+            raise ValueError(
+                f"Integer parameter: fidelity bounds error. Expected fidelity"
+                f" bounds to be >= 0, but got lower={self.lower}, "
+                f" upper={self.upper}."
+            )
 
         if self.log and (self.lower <= 0 or self.upper <= 0):
             raise ValueError(


### PR DESCRIPTION
* Closes #183

Issue #183 was discovered from additional tests done in #182.

The issue was related to transformations from uniform to integer which are now handled directly in `CategoricalToUnitTransform`, rather than delegating to `CategoricalToIntegerTransform`.

This also fixes a bug where the ID would start from `0` instead of our usual `1`, and consequently also fixes some issues with initial design in `ifbo`, along with `bo` when batching.