### PR TITLE
refactor(space): remove `centers` and `priors`

### DIFF
--- a/neps/optimizers/bracket_optimizer.py
+++ b/neps/optimizers/bracket_optimizer.py
@@ -261,9 +261,6 @@ class BracketOptimizer:
 
         # If we have no trials, we either go with the prior or just a sampled config
         if len(trials) == 0:
-            # NOTE: The `space.prior` might be only partially specified by a user,
-            # hence the usage of `space.centers` which is always fully defined and
-            # acts as a fallback if the prior is not defined.
             match self.sample_prior_first:
                 case "highest_fidelity":  # fid_max
                     config = {

--- a/neps/runtime.py
+++ b/neps/runtime.py
@@ -81,8 +81,6 @@ def _set_ddp_env_var(trial_id: str) -> None:
     os.environ[_DDP_ENV_VAR_NAME] = trial_id
 
 
-Loc = TypeVar("Loc")
-
 # NOTE: As each NEPS process is only ever evaluating a single trial, this global can
 # be retrieved in NePS and refers to what this process is currently evaluating.
 # Note that before `_set_in_progress_trial` is called, this should be cleared
@@ -158,7 +156,7 @@ def _set_global_trial(trial: Trial) -> Iterator[None]:
 # NOTE: This class is quite stateful and has been split up quite a bit to make testing
 # interleaving of workers easier. This comes at the cost of more fragmented code.
 @dataclass
-class DefaultWorker(Generic[Loc]):
+class DefaultWorker:
     """A default worker for the NePS system.
 
     This is the worker that is used by default in the neps.run() loop.

--- a/neps/space/search_space.py
+++ b/neps/space/search_space.py
@@ -25,38 +25,6 @@ class SearchSpace(Mapping[str, Parameter | Constant]):
     categoricals: Mapping[str, Categorical] = field(init=False)
     """The categorical hyperparameters in the search space."""
 
-    prior: dict[str, Any] = field(init=False, default_factory=dict)
-    """The prior configuration for the search space.
-
-    !!! warning
-
-        This will only contain the priors for the hyperparameters that have been
-        specified. If a hyperparameter does not have a prior, it will not be
-        included in this dictionary.
-
-        This is to ensure that anything which can deal with partial priors is
-        not fooled into thing some default value is a user set prior. For example,
-        all [`Prior`][neps.sampling.Prior] classes support partial priors, giving
-        a density around a specified prior and a uniform over the rest of the space.
-
-        If you require a fixed configuration that include the full or partial
-        prior, you can use the `centers` attribute, as this is gauranteed to
-        have a value for every hyperparameter.
-
-        ```python
-        # Ensure centers is first, so that any value specified in prior will
-        # override it.
-        config = {**space.centers, **space.prior}
-        ```
-    """
-
-    centers: dict[str, Any] = field(init=False, default_factory=dict)
-    """The centers of the hyperparameters in the search space.
-
-    Useful to combine with partial priors in the case that a prior is not fully
-    specified but you need some fixed, distinct point in the space.
-    """
-
     numerical: Mapping[str, Integer | Float] = field(init=False)
     """The numerical hyperparameters in the search space.
 


### PR DESCRIPTION
Use the `Parameter` `.center` and `.prior` as needed instead.