### PR TITLE
fix: Tensor decoded value overflow for parameters with log

### DIFF
--- a/neps/space/domain.py
+++ b/neps/space/domain.py
@@ -281,6 +281,16 @@ class Domain(Generic[V]):
         if self.round:
             x = torch.round(x)
 
+        if (x > upper).any():
+            import warnings
+            warnings.warn(  # noqa: B028
+                "Decoded value is above the upper bound of the domain. "
+                "Clipping to the upper bound. "
+                "This is likely due floating point precision in `torch.exp(x)` "
+                "with torch.float64."
+            )
+            x = torch.clip(x, max=self.upper)
+
         return x.type(dtype)
 
     def cast(self, x: Tensor, frm: Domain, *, dtype: torch.dtype | None = None) -> Tensor:

--- a/neps/space/domain.py
+++ b/neps/space/domain.py
@@ -283,6 +283,7 @@ class Domain(Generic[V]):
 
         if (x > upper).any():
             import warnings
+
             warnings.warn(  # noqa: B028
                 "Decoded value is above the upper bound of the domain. "
                 "Clipping to the upper bound. "


### PR DESCRIPTION
Fixes #214
Code snippet that fixes it: https://github.com/automl/neps/blob/oob-clip/neps/space/domain.py#L284-L293

Use the same code in #214 to check.