### PR TITLE
fix: Allow partial priors

### DIFF
--- a/neps/optimizers/algorithms.py
+++ b/neps/optimizers/algorithms.py
@@ -969,7 +969,7 @@ def priorband(
             `N` * `maximum_fidelity` worth of fidelity has been evaluated,
             proceed with bayesian optimization when sampling a new configuration.
     """
-    if not any(parameter.prior is not None for parameter in space.searchables.values()):
+    if all(parameter.prior is None for parameter in space.searchables.values()):
         logger.warning(
             "Warning: No priors are defined in the search space, priorband will sample"
             " uniformly. Consider using hyperband instead."
@@ -1120,7 +1120,7 @@ def pibo(
         ignore_fidelity: Whether to ignore the fidelity parameter when sampling.
             In this case, the max fidelity is always used.
     """
-    if not any(parameter.prior is not None for parameter in space.searchables.values()):
+    if all(parameter.prior is None for parameter in space.searchables.values()):
         logger.warning(
             "Warning: PiBO was called without any priors - using uniform priors on all"
             " parameters.\nConsider using Bayesian Optimization instead."

--- a/neps/sampling/priors.py
+++ b/neps/sampling/priors.py
@@ -393,7 +393,13 @@ class CenteredPrior(Prior):
         # respective distributions.
         # NOTE: There's no gaurantee these are actually probabilities and so we
         # treat them as unnormalized log pdfs
-        itr = iter(zip(self._meaningful_ixs, self._meaningful_dists, strict=False))
+        itr = iter(
+            zip(
+                range(len(self._meaningful_dists)),
+                self._meaningful_dists,
+                strict=False,
+            )
+        )
         first_i, first_dist = next(itr)
         log_pdfs = first_dist.log_prob(translated_x[..., first_i])
 

--- a/tests/test_state/test_neps_state.py
+++ b/tests/test_state/test_neps_state.py
@@ -143,7 +143,7 @@ def optimizer_and_key_and_search_space(
     if key in REQUIRES_FIDELITY and search_space.fidelity is None:
         pytest.xfail(f"{key} requires a fidelity parameter")
 
-    if key in REQUIRES_PRIOR and any(
+    if key in REQUIRES_PRIOR and all(
         parameter.prior is None for parameter in search_space.searchables.values()
     ):
         pytest.xfail(f"{key} requires a prior")


### PR DESCRIPTION
# Features and/or fixes:
* Apply a fix [here](https://github.com/automl/neps/blob/partial_priors/neps/sampling/priors.py#L398) which replaces `self._meaningful_ixs`, which causes the code to crash in the presence of Categoricals in the space or non-prior Parameters in between Paraneters with priors. Fix for issue #28
* Allow partial priors in `REQUIRES_PRIOR` test [here](https://github.com/automl/neps/blob/partial_priors/tests/test_state/test_neps_state.py#L146)

Code for Reproducibility:
``` python
import numpy as np

import neps
from neps import AskAndTell, algorithms
from neps.space.parsing import convert_to_space


def evaluate_pipeline(float1, float2, float3, float4, cat, float5, float6):
    return -float(
        np.sum([float1, float2, float3, float4, float5, float6])
    )

pipeline_space = {
    "float1": neps.Float(lower=0, upper=1, prior=1, prior_confidence="high"),
    "float2": neps.Float(lower=75, upper=1000, prior=85, prior_confidence="high"),
    "cat": neps.Categorical(choices=["a", "b", "c"]),
    "float3": neps.Float(lower=1, upper=100, is_fidelity=True),
    "float4": neps.Float(lower=4, upper=6),
    "float5": neps.Float(lower=0, upper=10, prior=5, prior_confidence="high"),
    "float6": neps.Float(lower=1, upper=3),
}

optimizer = AskAndTell(
    algorithms.PredefinedOptimizers["priorband"](
        space=convert_to_space(pipeline_space),
    )
)

def set_seed(seed: int):  # noqa: D103
    import random

    import numpy as np
    import torch

    np.random.seed(seed)
    random.seed(seed)
    torch.manual_seed(seed)

set_seed(0)
for i in range(200):
    print(f"Iteration {i + 1}")
    trial = optimizer.ask()
    x = trial.config
    y = evaluate_pipeline(**x)
    optimizer.tell(trial=trial, result=y)
``` 