### PR TITLE
feat: Change Worker ID

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,7 +13,7 @@ pip install neural-pipeline-search
 
 ## The 3 Main Components
 
-1. **Establish a [`pipeline_space=`](reference/pipeline_space.md)**:
+1. **Establish a [`pipeline_space`](reference/pipeline_space.md)**:
 
 ```python
 pipeline_space={

--- a/neps/api.py
+++ b/neps/api.py
@@ -46,6 +46,7 @@ def run(  # noqa: C901, D417, PLR0913
     objective_value_on_error: float | None = None,
     cost_value_on_error: float | None = None,
     sample_batch_size: int | None = None,
+    worker_id: str | None = None,
     optimizer: (
         OptimizerChoice
         | Mapping[str, Any]
@@ -248,6 +249,21 @@ def run(  # noqa: C901, D417, PLR0913
                 be able to take into account the results of any new
                 evaluations, even if they were to come in relatively
                 quickly.
+
+        worker_id: An optional string to identify the worker (run instance).
+            If not provided, a `worker_id` will be automatically generated which follows this pattern:
+            `worker_<N>` where `<N>` is a unique integer for each worker and increnements with each new worker.
+            List of all workers that have been created so far is stored in
+            `root_directory/optimizer_state.pkl` in the attribute `worker_ids`.
+
+            ??? tip "Why specify a `worker_id`?"
+                This is useful when you want to keep track of which worker did what in the
+                results, e.g., when debugging or running on a cluster.
+
+            ??? warning "Douplication of `worker_id`"
+                Make sure that each worker has a unique `worker_id`, in case of duplication,
+                for protecting against overwriting results of other workers, the optimization
+                will be stopped with an error.
 
         optimizer: Which optimizer to use.
 
@@ -513,6 +529,7 @@ def run(  # noqa: C901, D417, PLR0913
         overwrite_optimization_dir=overwrite_root_directory,
         sample_batch_size=sample_batch_size,
         write_summary_to_disk=write_summary_to_disk,
+        worker_id=worker_id,
     )
 
     post_run_csv(root_directory)

--- a/neps/api.py
+++ b/neps/api.py
@@ -251,19 +251,20 @@ def run(  # noqa: C901, D417, PLR0913
                 quickly.
 
         worker_id: An optional string to identify the worker (run instance).
-            If not provided, a `worker_id` will be automatically generated which follows this pattern:
-            `worker_<N>` where `<N>` is a unique integer for each worker and increnements with each new worker.
-            List of all workers that have been created so far is stored in
-            `root_directory/optimizer_state.pkl` in the attribute `worker_ids`.
+            If not provided, a `worker_id` will be automatically generated using the pattern:
+            `worker_<N>`, where `<N>` is a unique integer for each worker and increments with each new worker.
+            A list of all workers created so far is stored in
+            `root_directory/optimizer_state.pkl` under the attribute `worker_ids`.
 
             ??? tip "Why specify a `worker_id`?"
-                This is useful when you want to keep track of which worker did what in the
-                results, e.g., when debugging or running on a cluster.
+                Specifying a `worker_id` is useful for tracking which worker performed specific tasks
+                in the results. For example, when debugging or running on a cluster, you can include
+                the process ID and machine name in the `worker_id` for better traceability.
 
-            ??? warning "Douplication of `worker_id`"
-                Make sure that each worker has a unique `worker_id`, in case of duplication,
-                for protecting against overwriting results of other workers, the optimization
-                will be stopped with an error.
+            ??? warning "Duplication of `worker_id`"
+                Ensure that each worker has a unique `worker_id`. If a duplicate `worker_id` is detected,
+                the optimization process will be stopped with an error to prevent overwriting the results
+                of other workers.
 
         optimizer: Which optimizer to use.
 

--- a/neps/state/neps_state.py
+++ b/neps/state/neps_state.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import io
 import logging
+import os
 import pickle
+import socket
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -256,6 +258,45 @@ class NePSState:
 
     all_best_configs: list = field(default_factory=list)
     """Trajectory to the newest incbumbent"""
+
+    def lock_and_set_new_worker_id(self, worker_id: str | None = None) -> str:
+        """Acquire the state lock and set a new worker id in the optimizer state.
+
+        Args:
+            worker_id: The worker id to set. If `None`, a new worker id will be generated.
+
+        Returns:
+            The worker id that was set.
+
+        Raises:
+                NePSError: If the worker id already exists.
+        """
+        with self._optimizer_lock.lock():
+            with self._optimizer_state_path.open("rb") as f:
+                opt_state: OptimizationState = pickle.load(f)  # noqa: S301
+                assert isinstance(opt_state, OptimizationState)
+                worker_id = (
+                    worker_id
+                    if worker_id is not None
+                    else _get_worker_name(
+                        len(opt_state.worker_ids)
+                        if opt_state.worker_ids is not None
+                        else 0
+                    )
+                )
+                if opt_state.worker_ids and worker_id in opt_state.worker_ids:
+                    raise NePSError(
+                        f"Worker id '{worker_id}' already exists, \
+                        reserved worker ids: {opt_state.worker_ids}"
+                    )
+                if opt_state.worker_ids is None:
+                    opt_state.worker_ids = []
+
+                opt_state.worker_ids.append(worker_id)
+            bytes_ = pickle.dumps(opt_state, protocol=pickle.HIGHEST_PROTOCOL)
+            with atomic_write(self._optimizer_state_path, "wb") as f:
+                f.write(bytes_)
+            return worker_id
 
     def lock_and_read_trials(self) -> dict[str, Trial]:
         """Acquire the state lock and read the trials."""
@@ -683,3 +724,7 @@ def _deserialize_optimizer_info(path: Path) -> OptimizerInfo:
             f" {path}. Expected a `dict` or `None`."
         )
     return OptimizerInfo(name=name, info=info or {})
+
+
+def _get_worker_name(idx: int) -> str:
+    return f"worker_{idx}-{socket.gethostname()}-{os.getpid()}"

--- a/neps/state/neps_state.py
+++ b/neps/state/neps_state.py
@@ -12,9 +12,7 @@ from __future__ import annotations
 
 import io
 import logging
-import os
 import pickle
-import socket
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -727,4 +725,4 @@ def _deserialize_optimizer_info(path: Path) -> OptimizerInfo:
 
 
 def _get_worker_name(idx: int) -> str:
-    return f"worker_{idx}-{socket.gethostname()}-{os.getpid()}"
+    return f"worker_{idx}"

--- a/neps/state/optimizer.py
+++ b/neps/state/optimizer.py
@@ -47,3 +47,5 @@ class OptimizationState:
     Please reach out to @eddiebergman if you have a use case for this so we can make
     it more robust.
     """
+    worker_ids: list[str] | None = None
+    """The list of workers that have been created so far."""

--- a/neps_examples/basic_usage/hyperparameters.py
+++ b/neps_examples/basic_usage/hyperparameters.py
@@ -1,7 +1,8 @@
 import logging
 import numpy as np
 import neps
-
+import socket
+import os
 # This example demonstrates how to use NePS to optimize hyperparameters
 # of a pipeline. The pipeline is a simple function that takes in
 # five hyperparameters and returns their sum.
@@ -28,5 +29,5 @@ neps.run(
     pipeline_space=pipeline_space,
     root_directory="results/hyperparameters_example",
     evaluations_to_spend=30,
-    worker_id="test_worker",
+    worker_id=f"worker_1-{socket.gethostname()}-{os.getpid()}",
 )

--- a/neps_examples/basic_usage/hyperparameters.py
+++ b/neps_examples/basic_usage/hyperparameters.py
@@ -28,4 +28,5 @@ neps.run(
     pipeline_space=pipeline_space,
     root_directory="results/hyperparameters_example",
     evaluations_to_spend=30,
+    worker_id="test_worker",
 )

--- a/tests/test_runtime/test_worker_creation.py
+++ b/tests/test_runtime/test_worker_creation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from neps.optimizers import OptimizerInfo
+from neps.optimizers.algorithms import random_search
+from neps.runtime import (
+    DefaultReportValues,
+    DefaultWorker,
+    OnErrorPossibilities,
+    WorkerSettings,
+)
+from neps.space import Float, SearchSpace
+from neps.state import NePSState, OptimizationState, SeedSnapshot
+
+
+@pytest.fixture
+def neps_state(tmp_path: Path) -> NePSState:
+    return NePSState.create_or_load(
+        path=tmp_path / "neps_state",
+        optimizer_info=OptimizerInfo(name="blah", info={"nothing": "here"}),
+        optimizer_state=OptimizationState(
+            budget=None, seed_snapshot=SeedSnapshot.new_capture(), shared_state={}
+        ),
+    )
+
+
+def test_create_worker_manual_id(neps_state: NePSState) -> None:
+    settings = WorkerSettings(
+        on_error=OnErrorPossibilities.IGNORE,
+        default_report_values=DefaultReportValues(),
+        max_evaluations_total=1,
+        include_in_progress_evaluations_towards_maximum=True,
+        max_cost_total=None,
+        max_evaluations_for_worker=None,
+        max_evaluation_time_total_seconds=None,
+        max_wallclock_time_for_worker_seconds=None,
+        max_evaluation_time_for_worker_seconds=None,
+        max_cost_for_worker=None,
+        batch_size=None,
+    )
+
+    def eval_fn(config: dict) -> float:
+        return 1.0
+
+    test_worker_id = "my_worker_123"
+    optimizer = random_search(SearchSpace({"a": Float(0, 1)}))
+
+    worker = DefaultWorker.new(
+        state=neps_state,
+        settings=settings,
+        optimizer=optimizer,
+        evaluation_fn=eval_fn,
+        worker_id=test_worker_id,
+    )
+
+    assert worker.worker_id == test_worker_id
+    assert neps_state.lock_and_get_optimizer_state().worker_ids == [test_worker_id]
+
+
+def test_create_worker_auto_id(neps_state: NePSState) -> None:
+    settings = WorkerSettings(
+        on_error=OnErrorPossibilities.IGNORE,
+        default_report_values=DefaultReportValues(),
+        max_evaluations_total=1,
+        include_in_progress_evaluations_towards_maximum=True,
+        max_cost_total=None,
+        max_evaluations_for_worker=None,
+        max_evaluation_time_total_seconds=None,
+        max_wallclock_time_for_worker_seconds=None,
+        max_evaluation_time_for_worker_seconds=None,
+        max_cost_for_worker=None,
+        batch_size=None,
+    )
+
+    def eval_fn(config: dict) -> float:
+        return 1.0
+
+    optimizer = random_search(SearchSpace({"a": Float(0, 1)}))
+
+    worker = DefaultWorker.new(
+        state=neps_state,
+        settings=settings,
+        optimizer=optimizer,
+        evaluation_fn=eval_fn,
+    )
+
+    assert worker.worker_id.startswith("worker_0")
+    assert neps_state.lock_and_get_optimizer_state().worker_ids == [worker.worker_id]

--- a/tests/test_runtime/test_worker_creation.py
+++ b/tests/test_runtime/test_worker_creation.py
@@ -31,15 +31,16 @@ def test_create_worker_manual_id(neps_state: NePSState) -> None:
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
-        max_evaluations_total=1,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=True,
-        max_cost_total=None,
+        cost_to_spend=None,
         max_evaluations_for_worker=None,
         max_evaluation_time_total_seconds=None,
         max_wallclock_time_for_worker_seconds=None,
         max_evaluation_time_for_worker_seconds=None,
         max_cost_for_worker=None,
         batch_size=None,
+        fidelities_to_spend=None,
     )
 
     def eval_fn(config: dict) -> float:
@@ -64,15 +65,16 @@ def test_create_worker_auto_id(neps_state: NePSState) -> None:
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
-        max_evaluations_total=1,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=True,
-        max_cost_total=None,
+        cost_to_spend=None,
         max_evaluations_for_worker=None,
         max_evaluation_time_total_seconds=None,
         max_wallclock_time_for_worker_seconds=None,
         max_evaluation_time_for_worker_seconds=None,
         max_cost_for_worker=None,
         batch_size=None,
+        fidelities_to_spend=None,
     )
 
     def eval_fn(config: dict) -> float:
@@ -87,5 +89,5 @@ def test_create_worker_auto_id(neps_state: NePSState) -> None:
         evaluation_fn=eval_fn,
     )
 
-    assert worker.worker_id.startswith("worker_0")
+    assert worker.worker_id == "worker_0"
     assert neps_state.lock_and_get_optimizer_state().worker_ids == [worker.worker_id]


### PR DESCRIPTION
Changes in this PR

We introduced two updates related to worker IDs:

Users can now explicitly specify the worker_id in neps.run.

By default, worker IDs follow this format:

`worker_i-hostname-pid`


where i is a zero-based index.
<pre> 
Example: User-specified worker_id
import logging
import numpy as np
import neps

def evaluate_pipeline(float1, float2):
    objective_to_minimize = -float(np.sum([float1, float2]))
    return objective_to_minimize

pipeline_space = dict(
    float1=neps.Float(lower=0, upper=1),
    float2=neps.Float(lower=-10, upper=10),
)

logging.basicConfig(level=logging.INFO)

neps.run(
    evaluate_pipeline=evaluate_pipeline,
    pipeline_space=pipeline_space,
    max_evaluations_total=30,
    worker_id="test_worker",  # user-defined worker_id
)
</pre>
