### PR TITLE
fix: remove write_summary_to_disk

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,6 @@ neps.run(
     pipeline_space=pipeline_space,
     root_directory="path/to/save/results",  # Replace with the actual path.
     evaluations_to_spend=100,
-    write_summary_to_disk=True,
 )
 
 # 4. status information about a neural pipeline search run, using:

--- a/docs/reference/analyse.md
+++ b/docs/reference/analyse.md
@@ -39,11 +39,7 @@ python -m neps.plot ROOT_DIRECTORY
 Currently, this creates one plot that shows the best error value across the number of evaluations.
 
 ## What's on disk?
-In the root directory, NePS maintains several files at all times that are human readable and can be useful
-If you pass the `write_summary_to_disk=` argument to [`neps.run()`][neps.api.run],
-NePS will generate a summary CSV and TXT files for you.  
-
-=== "`neps.run(..., write_summary_to_disk=True)`"
+NePS maintains several human-readable files in the `ROOT_DIRECTORY`. Additionally, it generates a summary folder (located at `ROOT_DIRECTORY/summary/`) which contains useful reports on the run.
 
     ```
     ROOT_DIRECTORY
@@ -60,21 +56,6 @@ NePS will generate a summary CSV and TXT files for you.
     ├── optimizer_info.yaml
     └── optimizer_state.pkl
     ```
-
-
-=== "`neps.run(..., write_summary_to_disk=False)`"
-
-    ```
-    ROOT_DIRECTORY
-    ├── results
-    │  └── config_1
-    │      ├── config.yaml
-    │      ├── metadata.yaml
-    │      └── report.yaml
-    ├── optimizer_info.yaml
-    └── optimizer_state.pkl
-    ```
-
 
 The `full.csv` contains all configuration details in CSV format.
 Details include configuration hyperparameters and any returned result and cost from the `evaluate_pipeline` function.

--- a/docs/reference/evaluate_pipeline.md
+++ b/docs/reference/evaluate_pipeline.md
@@ -45,7 +45,6 @@ All other values raise a `TypeError` inside NePS.
        user_result=result_dict,
        pipeline_id=pipeline_id,
        root_directory=root_directory,
-       post_run_summary=True,
    )
    ```
 
@@ -122,11 +121,8 @@ neps.save_pipeline_results(
     user_result=result,
     pipeline_id=args.pipeline_id,
     root_directory=Path(args.root_dir),
-    post_run_summary=False,
 )
 ```
-
-the default value for `post_run_summary` is True, if you want to prevent any summary creation, you should specify in the arguments.
 
 ### 3.3 Why this matters
 

--- a/docs/reference/neps_run.md
+++ b/docs/reference/neps_run.md
@@ -149,12 +149,6 @@ provided to [`neps.run()`][neps.api.run].
     └── optimizer_state.pkl     # The optimizer's state, shared between workers
     ```
 
-=== "python"
-
-    ```python
-    neps.run(..., write_summary_to_disk=True)
-    ```
-
 To capture the results of the optimization process, you can use tensorbaord logging with various utilities to integrate
 closer to NePS. For more information, please refer to the [analyses page](../reference/analyse.md) page.
 

--- a/neps/api.py
+++ b/neps/api.py
@@ -39,7 +39,6 @@ def run(  # noqa: C901, D417, PLR0913
     root_directory: str | Path = "neps_results",
     overwrite_root_directory: bool = False,
     evaluations_to_spend: int | None = None,
-    write_summary_to_disk: bool = True,
     max_evaluations_total: int | None = None,
     max_evaluations_per_run: int | None = None,
     continue_until_max_evaluation_completed: bool = False,
@@ -200,9 +199,6 @@ def run(  # noqa: C901, D417, PLR0913
 
         overwrite_root_directory: If true, delete the working directory at the start of
             the run. This is, e.g., useful when debugging a evaluate_pipeline function.
-
-        write_summary_to_disk: If True, creates a csv and txt files after each worker is done,
-            holding summary information about the configs and results.
 
         max_evaluations_per_run: Number of evaluations this specific call should do.
         ??? note "Limitation on Async mode"
@@ -538,30 +534,26 @@ def run(  # noqa: C901, D417, PLR0913
         ignore_errors=ignore_errors,
         overwrite_optimization_dir=overwrite_root_directory,
         sample_batch_size=sample_batch_size,
-        write_summary_to_disk=write_summary_to_disk,
         worker_id=worker_id,
     )
 
     post_run_csv(root_directory)
     root_directory = Path(root_directory)
     summary_dir = root_directory / "summary"
-    if not write_summary_to_disk:
-        trajectory_of_improvements(root_directory)
-        logger.info(
-            "The summary folder has been created, which contains csv and txt files with"
-            "the output of all data in the run (short.csv - only the best; full.csv - "
-            "all runs; best_config_trajectory.txt for incumbent trajectory; and "
-            "best_config.txt for final incumbent)."
-            f"\nYou can find summary folder at: {summary_dir}."
-        )
+    trajectory_of_improvements(root_directory)
+    logger.info(
+        "The summary folder has been created, which contains csv and txt files with"
+        "the output of all data in the run (short.csv - only the best; full.csv - "
+        "all runs; best_config_trajectory.txt for incumbent trajectory; and "
+        "best_config.txt for final incumbent)."
+        f"\nYou can find summary folder at: {summary_dir}."
+    )
 
 
 def save_pipeline_results(
     user_result: dict,
     pipeline_id: str,
     root_directory: Path,
-    *,
-    post_run_summary: bool = True,
 ) -> None:
     """Persist the outcome of one pipeline evaluation.
 
@@ -575,8 +567,6 @@ def save_pipeline_results(
             neps.core.trial.Trial object inside the optimisation state.
         root_directory (Path): Root directory of the NePS run (contains
             optimizer_info.yaml and configs/ folder).
-        post_run_summary (bool, optional): If True, creates a CSV file after
-            trial completion, holding summary info about configs and results.
 
     """
     _save_results(
@@ -585,14 +575,13 @@ def save_pipeline_results(
         root_directory=root_directory,
     )
 
-    if post_run_summary:
-        full_frame_path, short_path = post_run_csv(root_directory)
-        logger.info(
-            "The post run summary has been created, which is a csv file with the "
-            "output of all data in the run."
-            f"\nYou can find a full dataframe at: {full_frame_path}."
-            f"\nYou can find a quick summary at: {short_path}."
-        )
+    full_frame_path, short_path = post_run_csv(root_directory)
+    logger.info(
+        "The post run summary has been created, which is a csv file with the "
+        "output of all data in the run."
+        f"\nYou can find a full dataframe at: {full_frame_path}."
+        f"\nYou can find a quick summary at: {short_path}."
+    )
 
 
 def import_trials(

--- a/neps/state/settings.py
+++ b/neps/state/settings.py
@@ -188,8 +188,3 @@ class WorkerSettings:
     If `None`, there is no limit and this worker will continue to evaluate
     indefinitely or until another stopping criterion is met.
     """
-
-    write_summary_to_disk: bool = True
-    """If True, creates a csv and txt files after each worker is done,
-            holding summary information about the configs and results.
-    """

--- a/neps_examples/basic_usage/hyperparameters.py
+++ b/neps_examples/basic_usage/hyperparameters.py
@@ -28,6 +28,6 @@ neps.run(
     evaluate_pipeline=evaluate_pipeline,
     pipeline_space=pipeline_space,
     root_directory="results/hyperparameters_example",
-    evaluations_to_spend=30,
+    evaluations_to_spend=15,
     worker_id=f"worker_1-{socket.gethostname()}-{os.getpid()}",
 )


### PR DESCRIPTION
remove write_summary_to_disk flag from neps.run, and automatically write the summary after each evaluation.
remove post_run_summary from neps.save_pipeline_results and automatically write the summary after each evaluation.