### PR TITLE
feat: Remove global (cross-worker) stopping criteria

### DIFF
--- a/docs/reference/evaluate_pipeline.md
+++ b/docs/reference/evaluate_pipeline.md
@@ -132,7 +132,7 @@ neps.save_pipeline_results(
 
 ### 3.4 Common pitfalls
 
-* When using async approach, one worker, may create as many trials as possible, of course that in `Slurm` or other workload managers it's impossible to overload the system because of limitations set for each user, but if you want to control resources used for optimization, it's crucial to set `max_evaluations_per_run` when calling `neps.run`.
+* When using async approach, one worker, may create as many trials as possible, of course that in `Slurm` or other workload managers it's impossible to overload the system because of limitations set for each user, but if you want to control resources used for optimization, it's crucial to set `evaluations_to_spend` when calling `neps.run`.
 
 ## 4  Extra injected arguments
 

--- a/docs/reference/neps_run.md
+++ b/docs/reference/neps_run.md
@@ -167,8 +167,7 @@ Any new workers that come online will automatically pick up work and work togeth
         evaluate_pipeline=...,
         pipeline_space=...,
         root_directory="some/path",
-        evaluations_to_spend=100,
-        max_evaluations_per_run=10, # (1)!
+        evaluations_to_spend=100, # (1)!
         continue_until_max_evaluation_completed=True, # (2)!
         overwrite_root_directory=False, #!!!
     )
@@ -220,7 +219,7 @@ neps.run(
 
 !!! note
 
-    Any runs that error will still count towards the total `evaluations_to_spend` or `max_evaluations_per_run`.
+    Any runs that error will still count towards the total `evaluations_to_spend`.
 
 ### Re-running Failed Configurations
 

--- a/neps/state/settings.py
+++ b/neps/state/settings.py
@@ -77,18 +77,18 @@ class WorkerSettings:
     batch_size: int | None
     """The number of configurations to sample in a single batch."""
 
-    # --------- Global Stopping Criterion ---------
+    # --------- Stopping Criterion ---------
     evaluations_to_spend: int | None
     """The maximum number of evaluations to run in total.
 
-    Once this evaluation total is reached, **all** workers will stop evaluating
+    Once this evaluation total is reached, worker will stop evaluating
     new configurations.
 
     To control whether currently evaluating configurations are included in this
     total, see
     [`include_in_progress_evaluations_towards_maximum`][neps.state.settings.WorkerSettings.include_in_progress_evaluations_towards_maximum].
 
-    If `None`, there is no limit and workers will continue to evaluate
+    If `None`, there is no limit and worker will continue to evaluate
     indefinitely.
     """
 
@@ -101,82 +101,48 @@ class WorkerSettings:
     cost_to_spend: float | None
     """The maximum cost to run in total.
 
-    Once this cost total is reached, **all** workers will stop evaluating new
+    Once this cost total is reached, worker will stop evaluating new
     configurations.
 
     This cost is the sum of `'cost'` values that are returned by evaluation
     of the target function.
 
-    If `None`, there is no limit and workers will continue to evaluate
+    If `None`, there is no limit and worker will continue to evaluate
     indefinitely or until another stopping criterion is met.
     """
 
     fidelities_to_spend: int | float | None
     """The maximum number of evaluations to run in case of multi-fidelity.
 
-    Once this evaluation total is reached, **all** workers will stop evaluating
+    Once this evaluation total is reached, worker will stop evaluating
     new configurations.
 
     To control whether currently evaluating configurations are included in this
     total, see
     [`include_in_progress_evaluations_towards_maximum`][neps.state.settings.WorkerSettings.include_in_progress_evaluations_towards_maximum].
 
-    If `None`, there is no limit and workers will continue to evaluate
+    If `None`, there is no limit and worker will continue to evaluate
     indefinitely.
     """
 
     max_evaluation_time_total_seconds: float | None
-    """The maximum wallclock time allowed for evaluation in total.
+    """The maximum time allowed for evaluation duration in total.
+    This is the cumulative time reported by user for evaluation durations.
 
     !!! note
         This does not include time for sampling new configurations.
 
-    Once this wallclock time is reached, **all** workers will stop once their
+    Once this wallclock time is reached, worker will stop once its
     current evaluation is finished.
 
     If `None`, there is no limit and workers will continue to evaluate
     indefinitely or until another stopping criterion is met.
     """
 
-    # --------- Local Worker Stopping Criterion ---------
-    max_evaluations_for_worker: int | None
-    """The maximum number of evaluations to run for the worker.
-
-    This count is specific to each worker spawned by NePS.
-    **only** the current worker will stop evaluating new configurations once
-    this limit is reached.
-
-    If `None`, there is no limit and this worker will continue to evaluate
-    indefinitely or until another stopping criterion is met.
-    """
-
-    max_cost_for_worker: float | None
-    """The maximum cost incurred by a worker before finisihng.
-
-    Once this cost total is reached, **only** this worker will stop evaluating new
-    configurations.
-
-    This cost is the sum of `'cost'` values that are returned by evaluation
-    of the target function.
-
-    If `None`, there is no limit and the worker will continue to evaluate
-    indefinitely or until another stopping criterion is met.
-    """
-
-    max_evaluation_time_for_worker_seconds: float | None
-    """The maximum time to allow this worker for evaluating configurations.
-
-    !!! note
-        This does not include time for sampling new configurations.
-
-    If `None`, there is no limit and this worker will continue to evaluate
-    indefinitely or until another stopping criterion is met.
-    """
-
-    max_wallclock_time_for_worker_seconds: float | None
+    max_wallclock_time_seconds: float | None
     """The maximum wallclock time to run for this worker.
 
-    Once this wallclock time is reached, **only** this worker will stop evaluating
+    Once this wallclock time is reached, worker will stop evaluating
     new configurations.
 
     !!! warning

--- a/neps/state/trial.py
+++ b/neps/state/trial.py
@@ -25,7 +25,6 @@ class State(str, Enum):
 
     EXTERNAL = "external"
     PENDING = "pending"
-    SUBMITTED = "submitted"
     EVALUATING = "evaluating"
     SUCCESS = "success"
     FAILED = "failed"
@@ -191,11 +190,6 @@ class Trial:
     def id(self) -> str:
         """Return the id of the trial."""
         return self.metadata.id  # type: ignore
-
-    def set_submitted(self, *, time_submitted: float) -> None:
-        """Set the trial as submitted."""
-        self.metadata.time_submitted = time_submitted
-        self.metadata.state = State.SUBMITTED
 
     def set_evaluating(self, *, time_started: float, worker_id: int | str) -> None:
         """Set the trial as in progress."""

--- a/neps/status/status.py
+++ b/neps/status/status.py
@@ -42,6 +42,8 @@ class Summary:
             itertools.chain(*self.by_state.values()),
             key=lambda t: t.metadata.time_sampled,
         )
+        if len(trials) == 0:
+            return pd.DataFrame()
 
         # Config dataframe, config columns prefixed with `config.`
         config_df = (
@@ -244,6 +246,9 @@ def trajectory_of_improvements(
         return []
 
     df = summary.df()
+
+    if len(df) == 0:
+        return []
 
     if "time_sampled" not in df.columns:
         raise ValueError("Missing `time_sampled` column in summary DataFrame.")

--- a/neps_examples/basic_usage/hyperparameters.py
+++ b/neps_examples/basic_usage/hyperparameters.py
@@ -12,7 +12,7 @@ def evaluate_pipeline(float1, float2, categorical, integer1, integer2):
     objective_to_minimize = -float(
         np.sum([float1, float2, int(categorical), integer1, integer2])
     )
-    return objective_to_minimize
+    return {"objective_to_minimize": objective_to_minimize, "cost": categorical,}
     
 
 pipeline_space = dict(
@@ -29,5 +29,6 @@ neps.run(
     pipeline_space=pipeline_space,
     root_directory="results/hyperparameters_example",
     evaluations_to_spend=15,
+    cost_to_spend=2,
     worker_id=f"worker_1-{socket.gethostname()}-{os.getpid()}",
 )

--- a/neps_examples/convenience/async_evaluation/submit.py
+++ b/neps_examples/convenience/async_evaluation/submit.py
@@ -43,5 +43,5 @@ neps.run(
     evaluate_pipeline=evaluate_pipeline_via_slurm,
     pipeline_space=pipeline_space,
     root_directory="results",
-    max_evaluations_per_run=2,
+    evaluations_to_spend=2,
 )

--- a/tests/test_runtime/test_default_report_values.py
+++ b/tests/test_runtime/test_default_report_values.py
@@ -41,15 +41,12 @@ def test_default_values_on_error(
             cost_value_on_error=2.4,  # <- Highlight
             learning_curve_on_error=[2.4, 2.5],  # <- Highlight
         ),
-        evaluations_to_spend=None,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
         fidelities_to_spend=None,
-        max_evaluations_for_worker=1,
         max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
+        max_wallclock_time_seconds=None,
         batch_size=None,
     )
 
@@ -93,15 +90,12 @@ def test_default_values_on_not_specified(
             cost_if_not_provided=2.4,
             learning_curve_if_not_provided=[2.4, 2.5],
         ),
-        evaluations_to_spend=None,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
         fidelities_to_spend=None,
-        max_evaluations_for_worker=1,
         max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
+        max_wallclock_time_seconds=None,
         batch_size=None,
     )
 
@@ -143,15 +137,12 @@ def test_default_value_objective_to_minimize_curve_take_objective_to_minimize_va
         default_report_values=DefaultReportValues(
             learning_curve_if_not_provided="objective_to_minimize"
         ),
-        evaluations_to_spend=None,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
         fidelities_to_spend=None,
-        max_evaluations_for_worker=1,
         max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
+        max_wallclock_time_seconds=None,
         batch_size=None,
     )
 

--- a/tests/test_runtime/test_error_handling_strategies.py
+++ b/tests/test_runtime/test_error_handling_strategies.py
@@ -48,15 +48,12 @@ def test_worker_raises_when_error_in_self(
     settings = WorkerSettings(
         on_error=on_error,  # <- Highlight
         default_report_values=DefaultReportValues(),
-        evaluations_to_spend=None,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
         fidelities_to_spend=None,
-        max_evaluations_for_worker=1,
         max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
+        max_wallclock_time_seconds=None,
         batch_size=None,
     )
 
@@ -89,15 +86,12 @@ def test_worker_raises_when_error_in_other_worker(neps_state: NePSState) -> None
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.RAISE_ANY_ERROR,  # <- Highlight
         default_report_values=DefaultReportValues(),
-        evaluations_to_spend=None,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
         fidelities_to_spend=None,
-        max_evaluations_for_worker=1,
         max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
+        max_wallclock_time_seconds=None,
         batch_size=None,
     )
 
@@ -150,15 +144,12 @@ def test_worker_does_not_raise_when_error_in_other_worker(
     settings = WorkerSettings(
         on_error=on_error,  # <- Highlight
         default_report_values=DefaultReportValues(),
-        evaluations_to_spend=None,
+        evaluations_to_spend=1,
         include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
         fidelities_to_spend=None,
-        max_evaluations_for_worker=1,
         max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
+        max_wallclock_time_seconds=None,
         batch_size=None,
     )
 
@@ -190,21 +181,27 @@ def test_worker_does_not_raise_when_error_in_other_worker(
     evaler.do_raise = True
     with contextlib.suppress(WorkerRaiseError):
         worker1.run()
-    assert worker1.worker_cumulative_eval_count == 1
+
+    trials = list(neps_state.lock_and_read_trials().values())
+    assert (
+        sum(1 for t in trials if t.metadata.evaluating_worker_id == worker1.worker_id)
+        == 1
+    )
 
     # Worker2 should run successfully
     evaler.do_raise = False
     worker2.run()
-    assert worker2.worker_cumulative_eval_count == 1
+    trials = list(neps_state.lock_and_read_trials().values())
+    assert (
+        sum(1 for t in trials if t.metadata.evaluating_worker_id == worker2.worker_id)
+        == 1
+    )
 
-    trials = neps_state.lock_and_read_trials()
     n_success = sum(
-        trial.metadata.state == Trial.State.SUCCESS is not None
-        for trial in trials.values()
+        trial.metadata.state == Trial.State.SUCCESS is not None for trial in trials
     )
     n_crashed = sum(
-        trial.metadata.state == Trial.State.CRASHED is not None
-        for trial in trials.values()
+        trial.metadata.state == Trial.State.CRASHED is not None for trial in trials
     )
     assert n_success == 1
     assert n_crashed == 1

--- a/tests/test_runtime/test_save_evaluation_results.py
+++ b/tests/test_runtime/test_save_evaluation_results.py
@@ -36,18 +36,15 @@ def test_async_happy_path_changes_state(neps_state: NePSState) -> None:
     settings = WorkerSettings(
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(
-            cost_if_not_provided=1.2,
-        ),
-        cost_to_spend=None,
-        max_evaluations_for_worker=2,
-        max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
-        batch_size=None,
+            cost_if_not_provided=10
+        ),  # <- it is ignored
+        evaluations_to_spend=2,
+        include_in_progress_evaluations_towards_maximum=True,
+        cost_to_spend=1,
         fidelities_to_spend=None,
-        evaluations_to_spend=1,
-        include_in_progress_evaluations_towards_maximum=False,
+        max_evaluation_time_total_seconds=None,
+        max_wallclock_time_seconds=None,
+        batch_size=None,
     )
 
     callback_holder: list[callable] = []
@@ -78,7 +75,8 @@ def test_async_happy_path_changes_state(neps_state: NePSState) -> None:
 
     result_dict = {"objective_to_minimize": 0.3, "cost": 1.2}
     callback_holder[0](result_dict)
-    trial_iter = iter(neps_state.lock_and_read_trials().values())
+    trials = neps_state.lock_and_read_trials()
+    trial_iter = iter(trials.values())
     trial_after = next(trial_iter)
     assert trial_after.metadata.state == Trial.State.SUCCESS
     assert trial_after.report.objective_to_minimize == 0.3
@@ -87,3 +85,11 @@ def test_async_happy_path_changes_state(neps_state: NePSState) -> None:
     # second trial is not submitted yet
     trial_after = next(trial_iter)
     assert trial_after.metadata.state == Trial.State.EVALUATING
+
+    result_dict = {"objective_to_minimize": 10}  # cost not provided
+    callback_holder[1](result_dict)
+    trials = neps_state.lock_and_read_trials()
+    trial_after = list(trials.values())[1]
+    assert trial_after.metadata.state == Trial.State.SUCCESS
+    assert trial_after.report.objective_to_minimize == 10
+    assert trial_after.report.cost is None  # default is always None

--- a/tests/test_runtime/test_worker_creation.py
+++ b/tests/test_runtime/test_worker_creation.py
@@ -32,15 +32,12 @@ def test_create_worker_manual_id(neps_state: NePSState) -> None:
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
         evaluations_to_spend=1,
-        include_in_progress_evaluations_towards_maximum=True,
+        include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
-        max_evaluations_for_worker=None,
-        max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
-        batch_size=None,
         fidelities_to_spend=None,
+        max_evaluation_time_total_seconds=None,
+        max_wallclock_time_seconds=None,
+        batch_size=None,
     )
 
     def eval_fn(config: dict) -> float:
@@ -66,15 +63,12 @@ def test_create_worker_auto_id(neps_state: NePSState) -> None:
         on_error=OnErrorPossibilities.IGNORE,
         default_report_values=DefaultReportValues(),
         evaluations_to_spend=1,
-        include_in_progress_evaluations_towards_maximum=True,
+        include_in_progress_evaluations_towards_maximum=False,
         cost_to_spend=None,
-        max_evaluations_for_worker=None,
-        max_evaluation_time_total_seconds=None,
-        max_wallclock_time_for_worker_seconds=None,
-        max_evaluation_time_for_worker_seconds=None,
-        max_cost_for_worker=None,
-        batch_size=None,
         fidelities_to_spend=None,
+        max_evaluation_time_total_seconds=None,
+        max_wallclock_time_seconds=None,
+        batch_size=None,
     )
 
     def eval_fn(config: dict) -> float:


### PR DESCRIPTION
This PR restructures how stopping conditions are handled in NEPS by removing the old global, cross-worker logic and shifting all controlling parameters to the level of individual workers.

definition: A worker_id represents a single execution of neps.run. Running NEPS again—sequentially or in parallel—creates a new worker_id. Stopping parameters are scoped to that worker rather than shared across all active workers.

Previously, fidelity usage and total evaluations were tracked also in memory of the worker, and trial files on disk were not checked for a single worker. For avoiding inconsistency and having one single source of truth, this PR moves to a disk-based ground truth and removes the now-invalid parameters from the worker settings, e.g. max_evaluation_for_worker, max_cost_for_worker,..

The earlier design also treated fidelity_to_spend as a global limit across workers, which made it impossible to define per-worker limits, especially in multi-fidelity setups where evaluations_to_spend could not be combined with that system. cost_to_spend and evaluations_to_spend were effectively the same logic pretending to be different knobs.

Now each worker has its own independent stopping parameters, and multiple stopping criteria are supported instead of being restricted to just one.

One trade-off: when users pass something like evaluations_to_spend, they must be aware of how much has already been consumed by the worker and adjust the value accordingly after failures or restarts. This will be addressed by adding a new summary report—total evaluations, total evaluation time, total cost, total fidelity usage.

This brings the API closer to predictable, per-worker resource accounting while cleaning up several historical inconsistencies.